### PR TITLE
ci: add CI and release workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: make ci

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          release-type: node
+
+  publish:
+    needs: release-please
+    if: needs.release-please.outputs.releases_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,11 @@ test: # Run the test suite.
 lint: # Type-check without emitting.
 	npm run lint
 
+.PHONY: ci
+ci: # Run lint and tests (used by CI pipeline).
+	$(MAKE) lint
+	$(MAKE) test
+
 .PHONY: dev
 dev: # Start TypeScript compiler in watch mode. Alias 'workforest' to dev.
 	npm run dev


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow (lint + test on PRs and main pushes)
- Add Release Please workflow for automated versioning and npm publish with provenance
- Add `make ci` target to Makefile

Closes #2