### PR TITLE
fix: handle checkout from forest root

### DIFF
--- a/src/commands/checkout.test.ts
+++ b/src/commands/checkout.test.ts
@@ -55,6 +55,16 @@ describe("checkout command", () => {
     expect(stat.isDirectory()).toBe(true);
   });
 
+  it("creates a new tree when run from the forest root", async () => {
+    const config = { ...DEFAULT_CONFIG };
+    // repoRoot is the forest root (.workforest.yaml exists there but it's not a git repo)
+    const result = await checkoutCommand("fix-from-root", repoRoot, config);
+    expect(result.created).toBe(true);
+    expect(result.treePath).toBe(path.join(repoRoot, "fix-from-root"));
+    const stat = await fs.stat(result.treePath);
+    expect(stat.isDirectory()).toBe(true);
+  });
+
   it("throws when not inside a workforest", async () => {
     const randomDir = await fs.mkdtemp(path.join(os.tmpdir(), "wf-no-forest-"));
     const config = { ...DEFAULT_CONFIG };

--- a/src/commands/checkout.ts
+++ b/src/commands/checkout.ts
@@ -27,7 +27,19 @@ export async function checkoutCommand(
     return { treePath: match.path, branch: match.branch, created: false };
   }
 
-  const gitRoot = await getRepoRoot(cwd);
+  // resolve git root from cwd if inside a tree, or fall back to an existing
+  // tree when running from the forest root (which is not a git repo itself)
+  let gitRoot: string;
+  try {
+    gitRoot = await getRepoRoot(cwd);
+  } catch {
+    if (trees.length === 0) {
+      throw new Error(
+        "no git trees found in forest.\ntry 'git forest clone <org/repo>' to add a repo",
+      );
+    }
+    gitRoot = await getRepoRoot(trees[0].path);
+  }
   const treePath = resolveTreePath(forestRoot, config.treeDir, branch);
 
   if (config.fatTrees) {


### PR DESCRIPTION
When running `git forest checkout <branch>` from the forest root directory, `git rev-parse --show-toplevel` fails because the forest root is not itself a git repository. Fix by falling back to an existing tree's path to resolve the git root when cwd is not inside a git worktree.

Closes #9

Generated with [Claude Code](https://claude.ai/code)