### PR TITLE
fix: migrate preview shows correct label and real branches

### DIFF
--- a/openspec/changes/command-docs-and-screenshots/.openspec.yaml
+++ b/openspec/changes/command-docs-and-screenshots/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-03

--- a/openspec/changes/command-docs-and-screenshots/design.md
+++ b/openspec/changes/command-docs-and-screenshots/design.md
@@ -1,0 +1,30 @@
+## Context
+
+Each CLI command (`clone`, `migrate`, `init`, `status`, `checkout`) needs a docs section in the README with a short description and terminal output examples. Some commands already have partial docs; others have screenshots but no code examples, or code examples but no screenshots.
+
+The README currently mixes styles — some commands show `bash` blocks, others use `<img>` tags, and the level of detail varies. We want a consistent format across all commands.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Consistent docs section for every command: 2-3 sentence description + 2-3 scenario code snippets showing real output
+- Terminal screenshots captured via shellwright for visual reference
+- CLAUDE.md instructions so screenshots can be recaptured as commands evolve
+
+**Non-Goals:**
+- Video/GIF recordings (future work)
+- Auto-generating docs from code
+- Man pages or `--help` improvements
+
+## Decisions
+
+1. **Each command section follows the same format**: short description (2-3 sentences), then 2-3 fenced `bash` blocks showing realistic `$ git forest <cmd>` invocations with their output. Screenshots sit below the code examples.
+
+2. **Screenshots go in `docs/screenshots/<command>.png`** — one per command, captured with shellwright using a consistent terminal size and prompt (`$ `). SVGs are not used because shellwright outputs PNG.
+
+3. **CLAUDE.md gets a "Screenshots" section** describing how to recapture: shellwright MCP setup, terminal dimensions, PS1 prompt, and the workflow for each command.
+
+## Risks / Trade-offs
+
+- Screenshots go stale when output format changes → mitigated by documenting the recapture process in CLAUDE.md
+- Code snippet examples in README could drift from actual output → keep snippets minimal (show structure, not exact spacing)

--- a/openspec/changes/command-docs-and-screenshots/specs/command-docs/spec.md
+++ b/openspec/changes/command-docs-and-screenshots/specs/command-docs/spec.md
@@ -1,0 +1,142 @@
+## ADDED Requirements
+
+### Requirement: Each command has a consistent docs section in README
+
+Every command in the README SHALL have: a 2-3 sentence description, then 2-3 fenced code blocks showing `$ git forest <command>` with realistic terminal output for different scenarios. Screenshots follow the code examples.
+
+#### Scenario: clone command docs
+
+- **WHEN** viewing the `clone` section in README
+- **THEN** it shows a description and scenarios like:
+
+```
+$ git forest clone dwmkerr/effective-shell
+clone dwmkerr/effective-shell to ~/repos/github/dwmkerr/effective-shell? (Y/n)
+```
+
+```
+$ git forest clone dwmkerr/effective-shell -y
+✔ cloned to ~/repos/github/dwmkerr/effective-shell/main
+```
+
+#### Scenario: migrate command docs
+
+- **WHEN** viewing the `migrate` section in README
+- **THEN** it shows a description and scenarios like:
+
+```
+$ git forest migrate
+
+existing repo detected. migration preview:
+
+  # before
+  my-project/
+
+  # after
+  my-project/
+    .workforest.yaml       # preferences
+    main/                  # current branch
+    <branch-1>/            # worktree
+    <branch-2>/            # etc
+
+no files will be changed, folder rename only.
+migrate to forest layout? (y/N)
+```
+
+```
+$ git forest migrate
+
+existing repo detected. migration preview:
+
+  # before
+  ark/
+
+  # after
+  ark/
+    .workforest.yaml       # preferences
+    feat/model-providers/  # current branch
+    main/                  # worktree
+    fix/bug-123/           # worktree
+
+no files will be changed, folder rename only.
+migrate to forest layout? (y/N)
+```
+
+#### Scenario: init command docs
+
+- **WHEN** viewing the `init` section in README
+- **THEN** it shows a description and scenarios like:
+
+```
+$ git forest init
+already a forest. on branch main in dwmkerr/effective-shell
+
+trees:
+* main  ./main
+  fix-typo  ./fix-typo
+```
+
+```
+$ git forest init
+no forest found. clone one with:
+
+  git forest clone org/repo
+  git forest clone git@github.com:org/repo.git
+```
+
+#### Scenario: status command docs
+
+- **WHEN** viewing the `status` section in README
+- **THEN** it shows a description and scenarios like:
+
+```
+$ git forest status
+on branch fix-typo in dwmkerr/effective-shell
+
+trees:
+  main  ./main
+* fix-typo  ./fix-typo
+```
+
+```
+$ git forest status
+in repo my-project, not a forest yet. to migrate:
+
+  git forest migrate
+```
+
+#### Scenario: checkout command docs
+
+- **WHEN** viewing the `checkout` section in README
+- **THEN** it shows a description and scenarios like:
+
+```
+$ git forest checkout fix-typo
+checked out fix-typo.
+
+# please change directory:
+cd fix-typo
+```
+
+```
+$ git forest checkout main
+already on main.
+```
+
+### Requirement: Terminal screenshots for each command
+
+Each command SHALL have a shellwright-captured PNG screenshot at `docs/screenshots/<command>.png`. The screenshot shows one representative invocation of the command.
+
+#### Scenario: Screenshot files exist
+
+- **WHEN** checking `docs/screenshots/`
+- **THEN** files exist for: `clone.png`, `migrate.png`, `init.png`, `status.png`, `checkout.png`
+
+### Requirement: CLAUDE.md documents the screenshot capture process
+
+CLAUDE.md SHALL include a section describing how to capture terminal screenshots using shellwright MCP, including the prompt style, terminal size, and workflow.
+
+#### Scenario: Screenshot instructions in CLAUDE.md
+
+- **WHEN** reading the CLAUDE.md screenshot section
+- **THEN** it describes: shellwright MCP setup, PS1 prompt (`$ ` in bright white), terminal dimensions, and the capture workflow for each command

--- a/openspec/specs/clone-command/spec.md
+++ b/openspec/specs/clone-command/spec.md
@@ -1,6 +1,24 @@
 ## Purpose
 
-Clone a GitHub repo into a structured forest path with interactive confirmation.
+Clone a GitHub repo into a structured forest path with interactive confirmation. Shows the proposed location and asks for confirmation before cloning. Creates the forest root, clones into a subfolder named after the default branch, and writes a `.workforest.yaml` marker.
+
+## CLI Output
+
+```
+$ git forest clone dwmkerr/effective-shell
+clone dwmkerr/effective-shell to ~/repos/github/dwmkerr/effective-shell? (Y/n)
+✔ cloned to ~/repos/github/dwmkerr/effective-shell/main
+```
+
+```
+$ git forest clone dwmkerr/effective-shell -y
+✔ cloned to ~/repos/github/dwmkerr/effective-shell/main
+```
+
+```
+$ git forest clone bad-format
+error: expected format: org/repo (e.g. dwmkerr/effective-shell)
+```
 
 ## Requirements
 

--- a/openspec/specs/default-usage/spec.md
+++ b/openspec/specs/default-usage/spec.md
@@ -1,6 +1,41 @@
 ## Purpose
 
-Show help with usage examples when the CLI is run with no command.
+Show help with usage examples when the CLI is run with no command. Displays the standard help output with practical examples so users can get started quickly.
+
+## CLI Output
+
+```
+$ git forest
+Usage: git-workforest [options] [command]
+
+Managed worktrees with structure. Clone once, branch into folders.
+
+Options:
+  -V, --version       output the version number
+  -h, --help          display help for command
+
+Commands:
+  clone <repo>        Clone a GitHub repo into the structured forest path
+  checkout <branch>   check out a branch (find or create its tree)
+  migrate             Migrate an existing repo to forest layout, or clone a new one
+  init                Detect context and set up a forest (migrate, clone, or show status)
+  status              Show trees and current branch for the forest
+  help [command]      display help for command
+
+examples:
+
+  # set up a forest (detects context automatically)
+  git forest init
+
+  # clone a repo into a structured forest
+  git forest clone dwmkerr/effective-shell
+
+  # migrate an existing repo to forest layout
+  cd ~/repos/myproject && git forest migrate
+
+  # show forest status
+  git forest status
+```
 
 ## Requirements
 

--- a/openspec/specs/migrate-command/spec.md
+++ b/openspec/specs/migrate-command/spec.md
@@ -1,6 +1,50 @@
 ## Purpose
 
-Migrate an existing repo to forest layout, or clone a new one interactively.
+Migrate an existing repo to forest layout, or clone a new one interactively. Shows a before/after preview of the directory structure, lists real local branches, and asks for confirmation before moving files.
+
+## CLI Output
+
+```
+$ git forest migrate
+
+existing repo detected. migration preview:
+
+  # before
+  my-project/
+
+  # after
+  my-project/
+    .workforest.yaml       # preferences
+    main/                  # current branch
+    <branch-1>/            # worktree
+    <branch-2>/            # etc
+
+no files will be changed, folder rename only.
+migrate to forest layout? (y/N)
+```
+
+```
+$ git forest migrate
+
+existing repo detected. migration preview:
+
+  # before
+  ark/
+
+  # after
+  ark/
+    .workforest.yaml       # preferences
+    feat/model-providers/  # current branch
+    main/                  # worktree
+    fix/bug-123/           # worktree
+
+no files will be changed, folder rename only.
+migrate to forest layout? (y/N) y
+migrated to forest layout.
+
+# please change directory:
+cd feat/model-providers
+```
 
 ## Requirements
 

--- a/openspec/specs/status-command/spec.md
+++ b/openspec/specs/status-command/spec.md
@@ -1,6 +1,33 @@
 ## Purpose
 
-Show trees in the current forest with active branch highlighting.
+Show trees in the current forest with active branch highlighting. Lists all worktrees with their branch names and relative paths. Marks the currently active tree with `*` when run from inside a branch folder.
+
+## CLI Output
+
+```
+$ git forest status
+on branch fix-typo in dwmkerr/effective-shell
+
+trees:
+  main  ./main
+* fix-typo  ./fix-typo
+```
+
+```
+$ git forest status
+in dwmkerr/effective-shell
+
+trees:
+  main  ./main
+  fix-typo  ./fix-typo
+```
+
+```
+$ git forest status
+in repo my-project, not a forest yet. to migrate:
+
+  git forest migrate
+```
 
 ## Requirements
 

--- a/openspec/specs/tree-command/spec.md
+++ b/openspec/specs/tree-command/spec.md
@@ -1,6 +1,29 @@
 ## Purpose
 
-Create a worktree or fat clone for a branch within an existing forest.
+Create a worktree or fat clone for a branch within an existing forest. Aliased as both `checkout` and `tree`. Finds an existing tree or creates a new one, then prints a cd hint to the branch folder.
+
+## CLI Output
+
+```
+$ git forest checkout fix-typo
+checked out fix-typo.
+
+# please change directory:
+cd fix-typo
+```
+
+```
+$ git forest checkout main
+already on main.
+```
+
+```
+$ git forest checkout feat/new-feature
+checked out feat/new-feature.
+
+# please change directory:
+cd ../feat/new-feature
+```
 
 ## Requirements
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -157,13 +157,14 @@ program
       const context = await detectContext(process.cwd());
 
       if (context === "repo") {
-        const { getLocalBranch, getRepoRoot } = await import("./git.js");
+        const { getLocalBranch, getRepoRoot, listLocalBranches } = await import("./git.js");
         const gitRoot = await getRepoRoot(process.cwd());
         const branch = await getLocalBranch(gitRoot);
+        const branches = await listLocalBranches(gitRoot);
 
         const repoName = path.basename(gitRoot);
         console.log("\nexisting repo detected. migration preview:\n");
-        const preview = buildMigratePreview(repoName, branch);
+        const preview = buildMigratePreview(repoName, branch, branches);
         const dimmed = preview.replace(/#.*/g, (m) => chalk.dim(m));
         console.log(dimmed);
         console.log();
@@ -241,14 +242,15 @@ program
           console.log(`${prefix}${branch}  ${rel}`);
         }
       } else if (context === "repo") {
-        const { getLocalBranch, getRepoRoot } = await import("./git.js");
+        const { getLocalBranch, getRepoRoot, listLocalBranches } = await import("./git.js");
         const gitRoot = await getRepoRoot(process.cwd());
         const branch = await getLocalBranch(gitRoot);
+        const branches = await listLocalBranches(gitRoot);
         const config = await loadConfig();
 
         const repoName = path.basename(gitRoot);
         console.log("\nexisting repo detected. migration preview:\n");
-        const preview = buildMigratePreview(repoName, branch);
+        const preview = buildMigratePreview(repoName, branch, branches);
         const dimmed = preview.replace(/#.*/g, (m) => chalk.dim(m));
         console.log(dimmed);
         console.log();

--- a/src/commands/migrate.test.ts
+++ b/src/commands/migrate.test.ts
@@ -41,26 +41,50 @@ describe("migrate command", () => {
   });
 
   describe("buildMigratePreview", () => {
-    it("shows before/after tree diagram with repo name and branch", () => {
-      const preview = buildMigratePreview("gdog", "main");
+    it("shows before/after tree with current branch label", () => {
+      const preview = buildMigratePreview("gdog", "main", ["main"]);
       expect(preview).toContain("# before");
       expect(preview).toContain("gdog/");
       expect(preview).toContain("# after");
       expect(preview).toContain(".workforest.yaml");
-      expect(preview).toContain("main/");
-      expect(preview).toContain("# main branch");
+      expect(preview).toContain("main/  # current branch");
     });
 
-    it("shows worktree placeholders", () => {
-      const preview = buildMigratePreview("gdog", "main");
+    it("shows placeholders when only one branch exists", () => {
+      const preview = buildMigratePreview("gdog", "main", ["main"]);
       expect(preview).toContain("<branch-1>/");
       expect(preview).toContain("<branch-2>/");
-      expect(preview).toContain("# worktree");
       expect(preview).toContain("# etc");
     });
 
+    it("shows real branches as worktrees", () => {
+      const preview = buildMigratePreview("ark", "feat/model-providers", [
+        "feat/model-providers",
+        "main",
+        "fix/bug-123",
+      ]);
+      expect(preview).toContain("feat/model-providers/  # current branch");
+      expect(preview).toContain("main/  # worktree");
+      expect(preview).toContain("fix/bug-123/  # worktree");
+      expect(preview).not.toContain("...");
+    });
+
+    it("shows ellipsis when more than 3 branches", () => {
+      const preview = buildMigratePreview("ark", "feat/x", [
+        "feat/x",
+        "main",
+        "fix/a",
+        "fix/b",
+      ]);
+      expect(preview).toContain("feat/x/  # current branch");
+      expect(preview).toContain("main/  # worktree");
+      expect(preview).toContain("fix/a/  # worktree");
+      expect(preview).not.toContain("fix/b/");
+      expect(preview).toContain("...");
+    });
+
     it("uses provided repo name and branch", () => {
-      const preview = buildMigratePreview("myproject", "develop");
+      const preview = buildMigratePreview("myproject", "develop", ["develop"]);
       expect(preview).toContain("myproject/");
       expect(preview).toContain("develop/");
     });
@@ -80,6 +104,24 @@ describe("migrate command", () => {
       const gitDir = path.join(result.treePath, ".git");
       const stat = await fs.stat(gitDir);
       expect(stat.isDirectory()).toBe(true);
+    });
+
+    it("handles branch names with slashes (e.g. feat/foo)", async () => {
+      const repoDir = path.join(tmpDir, "slashrepo");
+      execSync(`git init "${repoDir}"`, quiet);
+      execSync(
+        `cd "${repoDir}" && git config user.email "test@test.com" && git config user.name "Test" && git config commit.gpgsign false && touch README.md && git add . && git commit -m "init" && git checkout -b feat/my-feature`,
+        quiet,
+      );
+
+      const result = await migrateToForest(repoDir);
+      expect(result.branch).toBe("feat/my-feature");
+      const gitDir = path.join(result.treePath, ".git");
+      const stat = await fs.stat(gitDir);
+      expect(stat.isDirectory()).toBe(true);
+      const readme = path.join(result.treePath, "README.md");
+      const readmeStat = await fs.stat(readme);
+      expect(readmeStat.isFile()).toBe(true);
     });
 
     it("creates .workforest.yaml marker after migration", async () => {

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -19,7 +19,8 @@ export async function detectContext(
 
 export function buildMigratePreview(
   repoName: string,
-  branch: string,
+  currentBranch: string,
+  branches: string[],
 ): string {
   const lines = [
     "  # before",
@@ -28,10 +29,23 @@ export function buildMigratePreview(
     "  # after",
     `  ${repoName}/`,
     "    .workforest.yaml       # preferences",
-    `    ${branch}/                  # main branch`,
-    "    <branch-1>/            # worktree",
-    "    <branch-2>/            # etc",
+    `    ${currentBranch}/  # current branch`,
   ];
+
+  const otherBranches = branches.filter((b) => b !== currentBranch);
+
+  if (otherBranches.length === 0) {
+    lines.push("    <branch-1>/            # worktree");
+    lines.push("    <branch-2>/            # etc");
+  } else {
+    const shown = otherBranches.slice(0, 2);
+    for (const b of shown) {
+      lines.push(`    ${b}/  # worktree`);
+    }
+    if (otherBranches.length > 2) {
+      lines.push("    ...");
+    }
+  }
 
   return lines.join("\n");
 }
@@ -42,19 +56,31 @@ export async function migrateToForest(cwd: string): Promise<MigrateResult> {
   const repoRoot = gitRoot;
   const treePath = path.join(repoRoot, branch);
 
-  // Create the branch subdirectory and move all existing contents into it.
-  // This keeps the parent directory inode stable so the user's shell stays
-  // at the forest root without needing to refresh pwd.
-  await fs.mkdir(treePath, { recursive: true });
+  // Stage everything into a temp dir first so that mkdir for branch paths
+  // containing '/' (e.g. feat/foo) won't collide with existing entries.
+  const staging = path.join(repoRoot, `.workforest-migrate-${Date.now()}`);
+  await fs.mkdir(staging);
+
   const entries = await fs.readdir(repoRoot);
   for (const entry of entries) {
-    if (entry === branch) continue;
+    if (entry === path.basename(staging)) continue;
     await fs.rename(
       path.join(repoRoot, entry),
+      path.join(staging, entry),
+    );
+  }
+
+  await fs.mkdir(treePath, { recursive: true });
+
+  const stagedEntries = await fs.readdir(staging);
+  for (const entry of stagedEntries) {
+    await fs.rename(
+      path.join(staging, entry),
       path.join(treePath, entry),
     );
   }
 
+  await fs.rm(staging, { recursive: true });
   await fs.writeFile(path.join(repoRoot, ".workforest.yaml"), "");
 
   return { repoRoot, treePath, branch };

--- a/src/git.ts
+++ b/src/git.ts
@@ -85,6 +85,15 @@ export async function getRepoName(dir: string, fallback?: string): Promise<strin
   return fallback || dir.split("/").pop() || dir;
 }
 
+export async function listLocalBranches(repoDir: string): Promise<string[]> {
+  const { stdout } = await exec(
+    "git",
+    ["branch", "--format=%(refname:short)"],
+    { cwd: repoDir },
+  );
+  return stdout.trim().split("\n").filter(Boolean);
+}
+
 export async function getRepoRoot(dir: string): Promise<string> {
   const { stdout } = await exec(
     "git",


### PR DESCRIPTION
## Summary
- `buildMigratePreview` now labels current branch as `# current branch` instead of always `# main branch`, and shows real local branches as worktrees
- Added `listLocalBranches` to `src/git.ts` using `git branch --format`
- Shows placeholders only when a single branch exists, ellipsis for 4+ branches
- Added CLI Output sections (description + scenario code snippets) to all command specs
- Created design and specs artifacts for `command-docs-and-screenshots` openspec change