### PR TITLE
fix: checkout existing remote branches instead of always creating new ones

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -109,13 +109,14 @@ program
   });
 
 program
-  .command("checkout <branch>")
+  .command("checkout <branch> [gitArgs...]")
   .alias("tree")
   .description("check out a branch (find or create its tree)")
-  .action(async (branch: string) => {
+  .allowUnknownOption()
+  .action(async (branch: string, gitArgs: string[]) => {
     try {
       const config = await loadConfig();
-      const result = await checkoutCommand(branch, process.cwd(), config);
+      const result = await checkoutCommand(branch, process.cwd(), config, gitArgs);
       const rel = path.relative(process.cwd(), result.treePath);
       if (result.created) {
         console.log(`checked out ${chalk.green(result.branch)}.`);

--- a/src/commands/checkout.test.ts
+++ b/src/commands/checkout.test.ts
@@ -10,6 +10,8 @@ describe("checkout command", () => {
   let tmpDir: string;
   let repoRoot: string;
   let mainDir: string;
+  let bareRepo: string;
+  let seedDir: string;
 
   const quiet = { stdio: "pipe" as const };
 
@@ -17,9 +19,9 @@ describe("checkout command", () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "wf-checkout-test-"));
     repoRoot = path.join(tmpDir, "myrepo");
     mainDir = path.join(repoRoot, "main");
-    const bareRepo = path.join(tmpDir, "bare.git");
+    bareRepo = path.join(tmpDir, "bare.git");
     execSync(`git init --bare "${bareRepo}"`, quiet);
-    const seedDir = path.join(tmpDir, "seed");
+    seedDir = path.join(tmpDir, "seed");
     execSync(`git clone "${bareRepo}" "${seedDir}"`, quiet);
     execSync(
       `cd "${seedDir}" && git config user.email "test@test.com" && git config user.name "Test" && git config commit.gpgsign false && touch README.md && git add . && git commit -m "init" && git push`,
@@ -63,6 +65,24 @@ describe("checkout command", () => {
     expect(result.treePath).toBe(path.join(repoRoot, "fix-from-root"));
     const stat = await fs.stat(result.treePath);
     expect(stat.isDirectory()).toBe(true);
+  });
+
+  it("checks out an existing remote branch instead of creating a new one", async () => {
+    // Push a branch to the remote via the seed repo
+    execSync(
+      `cd "${seedDir}" && git checkout -b fix/remote-branch && touch remote.txt && git add . && git commit -m "remote commit" && git push -u origin fix/remote-branch`,
+      quiet,
+    );
+    // Fetch in mainDir so it knows about the remote branch
+    execSync(`git fetch`, { cwd: mainDir, ...quiet });
+
+    const config = { ...DEFAULT_CONFIG };
+    const result = await checkoutCommand("fix/remote-branch", mainDir, config);
+    expect(result.created).toBe(true);
+    expect(result.treePath).toBe(path.join(repoRoot, "fix/remote-branch"));
+    // The worktree should have the file from the remote branch
+    const stat = await fs.stat(path.join(result.treePath, "remote.txt"));
+    expect(stat.isFile()).toBe(true);
   });
 
   it("throws when not inside a workforest", async () => {

--- a/src/commands/checkout.ts
+++ b/src/commands/checkout.ts
@@ -13,6 +13,7 @@ export async function checkoutCommand(
   branch: string,
   cwd: string,
   config: WorkforestConfig,
+  extraArgs: string[] = [],
 ): Promise<CheckoutResult> {
   const forestRoot = await findForestRoot(cwd);
   if (!forestRoot) {
@@ -45,7 +46,7 @@ export async function checkoutCommand(
   if (config.fatTrees) {
     await gitFatClone(gitRoot, treePath, branch);
   } else {
-    await gitWorktreeAdd(gitRoot, treePath, branch);
+    await gitWorktreeAdd(gitRoot, treePath, branch, extraArgs);
   }
 
   return { treePath, branch, created: true };

--- a/src/git.ts
+++ b/src/git.ts
@@ -6,10 +6,11 @@ const exec = promisify(execFile);
 function run(
   cmd: string,
   args: string[],
-  opts: { cwd?: string } = {},
+  opts: { cwd?: string; quiet?: boolean } = {},
 ): Promise<void> {
   return new Promise((resolve, reject) => {
-    const child = spawn(cmd, args, { ...opts, stdio: "inherit" });
+    const { quiet, ...spawnOpts } = opts;
+    const child = spawn(cmd, args, { ...spawnOpts, stdio: quiet ? "pipe" : "inherit" });
     child.on("close", (code) =>
       code === 0 ? resolve() : reject(new Error(`${cmd} ${args.join(" ")} exited with ${code}`)),
     );
@@ -43,10 +44,19 @@ export async function gitWorktreeAdd(
   repoDir: string,
   treePath: string,
   branch: string,
+  extraArgs: string[] = [],
 ): Promise<void> {
-  await run("git", ["worktree", "add", "-b", branch, treePath, "HEAD"], {
-    cwd: repoDir,
-  });
+  try {
+    // Check out existing branch (local or remote tracking)
+    await run("git", ["worktree", "add", treePath, branch, ...extraArgs], {
+      cwd: repoDir, quiet: true,
+    });
+  } catch {
+    // Branch doesn't exist — create it
+    await run("git", ["worktree", "add", "-b", branch, treePath, ...extraArgs], {
+      cwd: repoDir,
+    });
+  }
 }
 
 export async function gitFatClone(
@@ -59,7 +69,13 @@ export async function gitFatClone(
   });
   const originUrl = stdout.trim();
   await exec("git", ["clone", originUrl, targetDir]);
-  await exec("git", ["checkout", "-b", branch], { cwd: targetDir });
+  try {
+    // Check out existing branch (local or remote tracking)
+    await exec("git", ["checkout", branch], { cwd: targetDir });
+  } catch {
+    // Branch doesn't exist — create it
+    await exec("git", ["checkout", "-b", branch], { cwd: targetDir });
+  }
 }
 
 export async function isInsideWorktree(dir: string): Promise<boolean> {


### PR DESCRIPTION
## Summary
- `git forest checkout` now checks out existing local/remote branches with proper tracking, instead of always creating a new branch from HEAD
- Extra git args are passed through to the underlying `git worktree add` command
- Suppresses noisy `fatal:` stderr when probing for existing branches