### PR TITLE
feat: git forest branch -l compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ Check out a branch — finds an existing tree or creates a new worktree. Also av
 
 <img src="docs/screenshots/checkout.png" width="600" alt="git forest checkout" />
 
+### `git forest branch [-l]`
+
+List all branches/trees in the forest. Mirrors `git branch -l` conventions: `*` marks the active branch, `+` marks other worktrees, and the default branch appears first with no prefix. The `-l` flag is accepted for git compatibility but listing is always the default behaviour.
+
+```
+  main  ./main
++ fix-typo  ./fix-typo
+* feat/new-ui  ./feat/new-ui
+```
+
 ### `git forest status`
 
 Show all trees in the current forest. Highlights the active branch when run from inside a tree.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ import readline from "readline/promises";
 import chalk from "chalk";
 import path from "path";
 import { statusTrees, formatTreeLine } from "./commands/status.js";
+import { branchCommand } from "./commands/branch.js";
 import { getRepoName } from "./git.js";
 
 const require = createRequire(import.meta.url);
@@ -328,5 +329,41 @@ program
   .command("status")
   .description("Show trees and current branch for the forest")
   .action(runStatus);
+
+program
+  .command("branch")
+  .description("List all branches/trees in the forest (like git branch -l)")
+  .option("-l, --list", "List branches (default behaviour)")
+  .action(async () => {
+    try {
+      const { forestRoot, trees } = await branchCommand(process.cwd());
+      for (const tree of trees) {
+        const prefix = tree.active ? "* " : tree.isDefault ? "  " : "+ ";
+        const branch = tree.active
+          ? chalk.green(tree.branch)
+          : tree.isDefault ? tree.branch : chalk.cyan(tree.branch);
+        const rel = chalk.whiteBright("./" + path.relative(forestRoot, tree.path));
+        console.log(`${prefix}${branch}  ${rel}`);
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes("not inside a workforest")) {
+        const context = await detectContext(process.cwd());
+        if (context === "repo") {
+          const { getRepoRoot } = await import("./git.js");
+          const gitRoot = await getRepoRoot(process.cwd());
+          const repoName = path.basename(gitRoot);
+          console.log(`in repo ${chalk.whiteBright(repoName)}, not a forest yet. to migrate:\n`);
+          console.log(`  ${chalk.whiteBright("git forest migrate")}`);
+        } else {
+          console.log("not in a repo. to get started:\n");
+          console.log(`  ${chalk.whiteBright("git forest clone org/repo")}`);
+        }
+      } else {
+        error(message);
+        process.exit(1);
+      }
+    }
+  });
 
 program.parse();

--- a/src/commands/branch.test.ts
+++ b/src/commands/branch.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { promises as fs } from "fs";
+import path from "path";
+import os from "os";
+import { execSync } from "child_process";
+import { branchCommand } from "./branch.js";
+
+describe("branch command", () => {
+  const quiet = { stdio: "pipe" as const };
+  let tmpDir: string;
+  let repoRoot: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "wf-branch-test-"));
+    repoRoot = path.join(tmpDir, "myrepo");
+    const bareRepo = path.join(tmpDir, "bare.git");
+    execSync(`git init --bare --initial-branch=main "${bareRepo}"`, quiet);
+    const seedDir = path.join(tmpDir, "seed");
+    execSync(`git clone "${bareRepo}" "${seedDir}"`, quiet);
+    execSync(
+      `cd "${seedDir}" && git config user.email "test@test.com" && git config user.name "Test" && git config commit.gpgsign false && touch README.md && git add . && git commit -m "init" && git push`,
+      quiet,
+    );
+    await fs.mkdir(repoRoot, { recursive: true });
+    execSync(`git clone "${bareRepo}" "${path.join(repoRoot, "main")}"`, quiet);
+    execSync(
+      `cd "${path.join(repoRoot, "main")}" && git worktree add -b fix-typo "${path.join(repoRoot, "fix-typo")}" HEAD`,
+      quiet,
+    );
+    await fs.writeFile(path.join(repoRoot, ".workforest.yaml"), "");
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true });
+  });
+
+  it("returns all branches in the forest", async () => {
+    const { trees } = await branchCommand(path.join(repoRoot, "main"));
+    const branches = trees.map((t) => t.branch);
+    expect(branches).toContain("main");
+    expect(branches).toContain("fix-typo");
+  });
+
+  it("marks the active branch when run from a tree folder", async () => {
+    const { trees } = await branchCommand(path.join(repoRoot, "fix-typo"));
+    const active = trees.find((t) => t.branch === "fix-typo");
+    const inactive = trees.find((t) => t.branch === "main");
+    expect(active?.active).toBe(true);
+    expect(inactive?.active).toBe(false);
+  });
+
+  it("marks no branch as active when run from the forest root", async () => {
+    const { trees } = await branchCommand(repoRoot);
+    expect(trees.some((t) => t.active)).toBe(false);
+  });
+
+  it("marks the default branch with isDefault", async () => {
+    const { trees } = await branchCommand(path.join(repoRoot, "main"));
+    const mainTree = trees.find((t) => t.branch === "main");
+    const fixTree = trees.find((t) => t.branch === "fix-typo");
+    expect(mainTree?.isDefault).toBe(true);
+    expect(fixTree?.isDefault).toBe(false);
+  });
+
+  it("sorts with default branch first", async () => {
+    const { trees } = await branchCommand(path.join(repoRoot, "main"));
+    expect(trees[0].branch).toBe("main");
+  });
+
+  it("throws with a helpful message when outside a forest", async () => {
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), "wf-no-forest-"));
+    try {
+      await expect(branchCommand(outside)).rejects.toThrow(
+        /not inside a workforest/,
+      );
+    } finally {
+      await fs.rm(outside, { recursive: true });
+    }
+  });
+});

--- a/src/commands/branch.ts
+++ b/src/commands/branch.ts
@@ -1,0 +1,8 @@
+import { statusTrees } from "./status.js";
+import type { ForestStatus } from "./status.js";
+
+export type { ForestStatus };
+
+export async function branchCommand(cwd: string): Promise<ForestStatus> {
+  return statusTrees(cwd);
+}


### PR DESCRIPTION
Implements `git forest branch` as a git-compatible way to list all trees/branches in the forest. Mirrors `git branch -l` conventions: `*` for the active branch (green), `+` for other worktrees (cyan), default branch first with no prefix. Accepts `-l`/`--list` flag for git compatibility.

Closes #16

Generated with [Claude Code](https://claude.ai/code)