### PR TITLE
fix: use scoped package name @dwmkerr/git-workforest for npm publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,6 @@ jobs:
           registry-url: https://registry.npmjs.org
       - run: npm ci
       - run: npm run build
-      - run: npm publish --provenance
+      - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <h2 align="center"><code>🌲 git-workforest</code></h2>
   <h3 align="center">Manage git worktrees with a simple, predictable folder structure.<br/>Like <code>git worktree</code>, but handles paths for you.</h3>
   <p align="center">
-    <a href="https://www.npmjs.com/package/workforest"><img src="https://img.shields.io/npm/v/workforest" alt="npm" /></a>
+    <a href="https://www.npmjs.com/package/@dwmkerr/git-workforest"><img src="https://img.shields.io/npm/v/@dwmkerr/git-workforest" alt="npm" /></a>
     <a href="https://codecov.io/gh/dwmkerr/git-workforest"><img src="https://codecov.io/gh/dwmkerr/git-workforest/branch/main/graph/badge.svg" alt="codecov" /></a>
     <a href="https://github.com/dwmkerr/git-workforest/actions/workflows/skill-tests.yaml"><img src="https://github.com/dwmkerr/git-workforest/actions/workflows/skill-tests.yaml/badge.svg" alt="skill tests" /></a>
   </p>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "workforest",
+  "name": "@dwmkerr/git-workforest",
   "version": "0.2.0",
   "description": "Managed worktrees with structure. Clone once, branch into folders.",
   "type": "module",


### PR DESCRIPTION
## Summary
- Rename npm package from `workforest` to `@dwmkerr/git-workforest`
- Add `--access public` to `npm publish` in release workflow (required for scoped packages)
- Update npm badge URLs in README to match