### PR TITLE
feat: add --verbose flag and -- passthrough for git params

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ Each branch gets its own folder inside the forest:
 
 Branches are created as git worktrees by default, so they share the same `.git` data. See [`fatTrees`](#configuration) if you need full clones<sup>1</sup>.
 
+## Global flags
+
+| Flag | Description |
+|------|-------------|
+| `-v, --verbose` | Print each git command and its output (dimmed) — useful for diagnosing unexpected behaviour |
+
+```bash
+git forest -v add fix-typo
+# $ git worktree add ../fix-typo fix-typo
+# added fix-typo.
+```
+
+You can also enable verbose mode permanently via the [config file](#configuration) (`verbose: true`).
+
 ## Commands
 
 ### `git forest list`
@@ -159,6 +173,7 @@ Customise behaviour in `~/.workforest.yaml`:
 reposDir: "~/repos/[provider]/[org]/[repo]"
 treeDir: "[branch]"
 fatTrees: false
+verbose: false
 ```
 
 | Parameter | Default | Description |
@@ -166,6 +181,7 @@ fatTrees: false
 | `reposDir` | `~/repos/[provider]/[org]/[repo]` | Path template for cloned repos. Tokens: `[provider]`, `[org]`, `[repo]` |
 | `treeDir` | `[branch]` | Subdirectory name for each tree. Token: `[branch]` |
 | `fatTrees` | `false` | Use full clones instead of git worktrees (see below) |
+| `verbose` | `false` | Print each git command and its output — same as passing `-v` on every command |
 
 <sup>1</sup> **Fat trees**: With worktrees, git prevents checking out a branch that's already checked out elsewhere. If you need to freely switch branches across trees, set `fatTrees: true` to use independent full clones instead.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -75,10 +75,10 @@ program
   .description("Clone a GitHub repo into the structured forest path")
   .option("-y, --yes", "Skip confirmation prompt")
   .action(async (repo: string, opts: { yes?: boolean }) => {
-    const { verbose } = program.opts();
     const spinner = ora();
     try {
       const config = await loadConfig();
+      const verbose = program.opts().verbose || config.verbose;
       const parts = repo.split("/");
       if (parts.length !== 2) {
         throw new Error(
@@ -119,9 +119,9 @@ program
   .description("add a tree for a branch (like git worktree add)")
   .allowUnknownOption()
   .action(async (branch: string, gitArgs: string[]) => {
-    const { verbose } = program.opts();
     try {
       const config = await loadConfig();
+      const verbose = program.opts().verbose || config.verbose;
       const result = await checkoutCommand(branch, process.cwd(), config, gitArgs, { verbose });
       const rel = path.relative(process.cwd(), result.treePath);
       if (result.created) {
@@ -158,10 +158,10 @@ program
   .command("migrate")
   .description("Migrate an existing repo to forest layout, or clone a new one")
   .action(async () => {
-    const { verbose } = program.opts();
     const spinner = ora();
     try {
       const config = await loadConfig();
+      const verbose = program.opts().verbose || config.verbose;
       const context = await detectContext(process.cwd());
 
       if (context === "repo") {
@@ -342,8 +342,9 @@ program
   .allowUnknownOption()
   .option("-f, --force", "force removal even if tree has uncommitted changes")
   .action(async (branch: string, gitArgs: string[], opts: { force?: boolean }) => {
-    const { verbose } = program.opts();
     try {
+      const config = await loadConfig();
+      const verbose = program.opts().verbose || config.verbose;
       const result = await removeCommand(branch, process.cwd(), opts.force, gitArgs, { verbose });
       console.log(`removed ${chalk.cyan(result.branch)}.`);
     } catch (err: unknown) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,6 +48,7 @@ program
     "Manage git worktrees with a simple, predictable folder structure.",
   )
   .version(version)
+  .option("-v, --verbose", "show git command output")
   .addHelpText(
     "after",
     `
@@ -74,6 +75,7 @@ program
   .description("Clone a GitHub repo into the structured forest path")
   .option("-y, --yes", "Skip confirmation prompt")
   .action(async (repo: string, opts: { yes?: boolean }) => {
+    const { verbose } = program.opts();
     const spinner = ora();
     try {
       const config = await loadConfig();
@@ -102,7 +104,7 @@ program
       }
 
       spinner.start(`cloning ${org}/${repoName}...`);
-      const result = await cloneCommand(repoUrl, org, repoName, config);
+      const result = await cloneCommand(repoUrl, org, repoName, config, { verbose });
       spinner.succeed(`cloned to ${result.treePath}`);
     } catch (err: unknown) {
       spinner.stop();
@@ -117,9 +119,10 @@ program
   .description("add a tree for a branch (like git worktree add)")
   .allowUnknownOption()
   .action(async (branch: string, gitArgs: string[]) => {
+    const { verbose } = program.opts();
     try {
       const config = await loadConfig();
-      const result = await checkoutCommand(branch, process.cwd(), config, gitArgs);
+      const result = await checkoutCommand(branch, process.cwd(), config, gitArgs, { verbose });
       const rel = path.relative(process.cwd(), result.treePath);
       if (result.created) {
         console.log(`added ${chalk.green(result.branch)}.`);
@@ -155,6 +158,7 @@ program
   .command("migrate")
   .description("Migrate an existing repo to forest layout, or clone a new one")
   .action(async () => {
+    const { verbose } = program.opts();
     const spinner = ora();
     try {
       const config = await loadConfig();
@@ -198,7 +202,7 @@ program
         const [org, repoName] = repo.split("/");
         const repoUrl = `git@github.com:${org}/${repoName}`;
         spinner.start(`cloning ${org}/${repoName}...`);
-        const result = await cloneCommand(repoUrl, org, repoName, config);
+        const result = await cloneCommand(repoUrl, org, repoName, config, { verbose });
         spinner.succeed(`cloned to ${result.treePath}`);
       }
     } catch (err: unknown) {
@@ -333,12 +337,14 @@ program
   .action(runStatus);
 
 program
-  .command("remove <branch>")
+  .command("remove <branch> [gitArgs...]")
   .description("remove a tree from the forest (like git worktree remove)")
+  .allowUnknownOption()
   .option("-f, --force", "force removal even if tree has uncommitted changes")
-  .action(async (branch: string, opts: { force?: boolean }) => {
+  .action(async (branch: string, gitArgs: string[], opts: { force?: boolean }) => {
+    const { verbose } = program.opts();
     try {
-      const result = await removeCommand(branch, process.cwd(), opts.force);
+      const result = await removeCommand(branch, process.cwd(), opts.force, gitArgs, { verbose });
       console.log(`removed ${chalk.cyan(result.branch)}.`);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);

--- a/src/commands/checkout.test.ts
+++ b/src/commands/checkout.test.ts
@@ -93,4 +93,14 @@ describe("checkout command", () => {
     ).rejects.toThrow("not inside a workforest");
     await fs.rm(randomDir, { recursive: true });
   });
+
+  it("passes extra args to git worktree add", async () => {
+    const config = { ...DEFAULT_CONFIG };
+    // --no-track is a valid git worktree add flag that shouldn't affect the result
+    const result = await checkoutCommand("extra-args-branch", mainDir, config, ["--no-track"]);
+    expect(result.created).toBe(true);
+    expect(result.treePath).toBe(path.join(repoRoot, "extra-args-branch"));
+    const stat = await fs.stat(result.treePath);
+    expect(stat.isDirectory()).toBe(true);
+  });
 });

--- a/src/commands/checkout.ts
+++ b/src/commands/checkout.ts
@@ -1,4 +1,5 @@
 import { gitWorktreeAdd, gitFatClone, getRepoRoot } from "../git.js";
+import type { GitOptions } from "../git.js";
 import type { WorkforestConfig } from "../config.js";
 import { resolveTreePath, findForestRoot } from "../paths.js";
 import { statusTrees } from "./status.js";
@@ -14,6 +15,7 @@ export async function checkoutCommand(
   cwd: string,
   config: WorkforestConfig,
   extraArgs: string[] = [],
+  opts: GitOptions = {},
 ): Promise<CheckoutResult> {
   const forestRoot = await findForestRoot(cwd);
   if (!forestRoot) {
@@ -44,9 +46,9 @@ export async function checkoutCommand(
   const treePath = resolveTreePath(forestRoot, config.treeDir, branch);
 
   if (config.fatTrees) {
-    await gitFatClone(gitRoot, treePath, branch);
+    await gitFatClone(gitRoot, treePath, branch, opts);
   } else {
-    await gitWorktreeAdd(gitRoot, treePath, branch, extraArgs);
+    await gitWorktreeAdd(gitRoot, treePath, branch, extraArgs, opts);
   }
 
   return { treePath, branch, created: true };

--- a/src/commands/clone.ts
+++ b/src/commands/clone.ts
@@ -2,6 +2,7 @@ import path from "path";
 import { promises as fs } from "fs";
 import { resolveRepoPath } from "../paths.js";
 import { gitClone, getDefaultBranch } from "../git.js";
+import type { GitOptions } from "../git.js";
 import type { WorkforestConfig } from "../config.js";
 
 export interface CloneResult {
@@ -15,6 +16,7 @@ export async function cloneCommand(
   org: string,
   repo: string,
   config: WorkforestConfig,
+  opts: GitOptions = {},
 ): Promise<CloneResult> {
   const repoRoot = resolveRepoPath(config.reposDir, {
     provider: "github",
@@ -24,7 +26,7 @@ export async function cloneCommand(
 
   const tmpClone = `${repoRoot}/.wf-clone-tmp`;
   await fs.mkdir(repoRoot, { recursive: true });
-  await gitClone(repoUrl, tmpClone);
+  await gitClone(repoUrl, tmpClone, opts);
 
   const defaultBranch = await getDefaultBranch(tmpClone);
   const treePath = path.join(repoRoot, defaultBranch);

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -1,21 +1,9 @@
 import { promises as fs } from "fs";
 import path from "path";
-import { execFile } from "child_process";
+import { gitExec } from "../git.js";
+import type { GitOptions } from "../git.js";
 import { findForestRoot } from "../paths.js";
 import { statusTrees } from "./status.js";
-
-function exec(
-  cmd: string,
-  args: string[],
-  opts: { cwd?: string } = {},
-): Promise<{ stdout: string; stderr: string }> {
-  return new Promise((resolve, reject) => {
-    execFile(cmd, args, opts, (err, stdout, stderr) => {
-      if (err) reject(err);
-      else resolve({ stdout: stdout ?? "", stderr: stderr ?? "" });
-    });
-  });
-}
 
 export interface RemoveResult {
   treePath: string;
@@ -26,6 +14,8 @@ export async function removeCommand(
   branch: string,
   cwd: string,
   force?: boolean,
+  extraArgs: string[] = [],
+  opts: GitOptions = {},
 ): Promise<RemoveResult> {
   const forestRoot = await findForestRoot(cwd);
   if (!forestRoot) {
@@ -50,10 +40,10 @@ export async function removeCommand(
   if (isWorktree) {
     // Use git worktree remove — it checks for uncommitted changes
     const gitRoot = await getWorktreeGitRoot(match.path);
-    const args = ["worktree", "remove", match.path];
+    const args = ["worktree", "remove", match.path, ...extraArgs];
     if (force) args.splice(2, 0, "--force");
     try {
-      await exec("git", args, { cwd: gitRoot });
+      await gitExec("git", args, { cwd: gitRoot, verbose: opts.verbose });
     } catch (err: unknown) {
       const msg = err instanceof Error ? (err as { stderr?: string }).stderr || err.message : String(err);
       if (msg.includes("contains modified or untracked files") || msg.includes("is dirty")) {
@@ -64,7 +54,7 @@ export async function removeCommand(
   } else {
     // Fat tree — check for uncommitted changes unless forced
     if (!force) {
-      const { stdout } = await exec("git", ["status", "--porcelain"], { cwd: match.path });
+      const { stdout } = await gitExec("git", ["status", "--porcelain"], { cwd: match.path, verbose: opts.verbose });
       if (stdout.trim()) {
         throw new Error(`tree '${branch}' has uncommitted changes. use -f to force.`);
       }
@@ -89,13 +79,13 @@ export async function removeCommand(
 
 async function checkIsWorktree(dir: string): Promise<boolean> {
   try {
-    const { stdout } = await exec(
+    const { stdout } = await gitExec(
       "git",
       ["rev-parse", "--git-common-dir"],
       { cwd: dir },
     );
     const commonDir = stdout.trim();
-    const { stdout: gitDir } = await exec(
+    const { stdout: gitDir } = await gitExec(
       "git",
       ["rev-parse", "--git-dir"],
       { cwd: dir },
@@ -108,7 +98,7 @@ async function checkIsWorktree(dir: string): Promise<boolean> {
 }
 
 async function getWorktreeGitRoot(dir: string): Promise<string> {
-  const { stdout } = await exec(
+  const { stdout } = await gitExec(
     "git",
     ["rev-parse", "--git-common-dir"],
     { cwd: dir },

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -10,6 +10,7 @@ describe("config", () => {
       expect(DEFAULT_CONFIG.reposDir).toBe("~/repos/[provider]/[org]/[repo]");
       expect(DEFAULT_CONFIG.treeDir).toBe("[branch]");
       expect(DEFAULT_CONFIG.fatTrees).toBe(false);
+      expect(DEFAULT_CONFIG.verbose).toBe(false);
     });
   });
 
@@ -28,6 +29,18 @@ describe("config", () => {
       expect(config.fatTrees).toBe(true);
       expect(config.reposDir).toBe("~/repos/[provider]/[org]/[repo]");
       expect(config.treeDir).toBe("[branch]");
+      expect(config.verbose).toBe(false);
+
+      await fs.rm(tmpDir, { recursive: true });
+    });
+
+    it("enables verbose mode from config", async () => {
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "wf-test-"));
+      const tmpConfig = path.join(tmpDir, ".workforest.yaml");
+      await fs.writeFile(tmpConfig, "verbose: true\n");
+
+      const config = await loadConfig(tmpConfig);
+      expect(config.verbose).toBe(true);
 
       await fs.rm(tmpDir, { recursive: true });
     });

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ const ConfigSchema = z.object({
   reposDir: z.string().default("~/repos/[provider]/[org]/[repo]"),
   treeDir: z.string().default("[branch]"),
   fatTrees: z.boolean().default(false),
+  verbose: z.boolean().default(false),
 });
 
 export type WorkforestConfig = z.infer<typeof ConfigSchema>;
@@ -16,6 +17,7 @@ export const DEFAULT_CONFIG: WorkforestConfig = {
   reposDir: "~/repos/[provider]/[org]/[repo]",
   treeDir: "[branch]",
   fatTrees: false,
+  verbose: false,
 };
 
 export async function loadConfig(

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { promises as fs } from "fs";
 import path from "path";
 import os from "os";
@@ -42,6 +42,17 @@ describe("git", () => {
       const gitDir = path.join(target, ".git");
       const stat = await fs.stat(gitDir);
       expect(stat.isDirectory()).toBe(true);
+    });
+
+    it("logs command and output when verbose is true", async () => {
+      const logs: string[] = [];
+      const spy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+        logs.push(args.map(String).join(" "));
+      });
+      const target = path.join(tmpDir, "cloned-verbose");
+      await gitClone(bareRepo, target, { verbose: true });
+      spy.mockRestore();
+      expect(logs.some((l) => l.includes("git clone"))).toBe(true);
     });
   });
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,25 +1,42 @@
 import { execFile } from "child_process";
+import chalk from "chalk";
+
+export interface GitOptions {
+  verbose?: boolean;
+}
 
 // promisify(execFile) can leave handles open that prevent node from exiting;
 // this wrapper resolves cleanly via the callback API
-function exec(
+export function gitExec(
   cmd: string,
   args: string[],
-  opts: { cwd?: string } = {},
+  opts: { cwd?: string; verbose?: boolean } = {},
 ): Promise<{ stdout: string; stderr: string }> {
+  const { verbose, ...execOpts } = opts;
   return new Promise((resolve, reject) => {
-    execFile(cmd, args, opts, (err, stdout, stderr) => {
+    if (verbose) {
+      console.log(chalk.dim(`$ ${cmd} ${args.join(" ")}`));
+    }
+    execFile(cmd, args, execOpts, (err, stdout, stderr) => {
+      if (verbose) {
+        if (stdout?.trim()) process.stdout.write(chalk.dim(stdout));
+        if (stderr?.trim()) process.stderr.write(chalk.dim(stderr));
+      }
       if (err) reject(err);
       else resolve({ stdout: stdout ?? "", stderr: stderr ?? "" });
     });
   });
 }
 
+// Internal alias for brevity
+const exec = gitExec;
+
 export async function gitClone(
   repoUrl: string,
   targetDir: string,
+  opts: GitOptions = {},
 ): Promise<void> {
-  await exec("git", ["clone", repoUrl, targetDir]);
+  await exec("git", ["clone", repoUrl, targetDir], { verbose: opts.verbose });
 }
 
 export async function getDefaultBranch(repoDir: string): Promise<string> {
@@ -43,16 +60,19 @@ export async function gitWorktreeAdd(
   treePath: string,
   branch: string,
   extraArgs: string[] = [],
+  opts: GitOptions = {},
 ): Promise<void> {
   try {
     // Check out existing branch (local or remote tracking)
     await exec("git", ["worktree", "add", treePath, branch, ...extraArgs], {
       cwd: repoDir,
+      verbose: opts.verbose,
     });
   } catch {
     // Branch doesn't exist — create it
     await exec("git", ["worktree", "add", "-b", branch, treePath, ...extraArgs], {
       cwd: repoDir,
+      verbose: opts.verbose,
     });
   }
 }
@@ -61,18 +81,20 @@ export async function gitFatClone(
   sourceDir: string,
   targetDir: string,
   branch: string,
+  opts: GitOptions = {},
 ): Promise<void> {
   const { stdout } = await exec("git", ["remote", "get-url", "origin"], {
     cwd: sourceDir,
+    verbose: opts.verbose,
   });
   const originUrl = stdout.trim();
-  await exec("git", ["clone", originUrl, targetDir]);
+  await exec("git", ["clone", originUrl, targetDir], { verbose: opts.verbose });
   try {
     // Check out existing branch (local or remote tracking)
-    await exec("git", ["checkout", branch], { cwd: targetDir });
+    await exec("git", ["checkout", branch], { cwd: targetDir, verbose: opts.verbose });
   } catch {
     // Branch doesn't exist — create it
-    await exec("git", ["checkout", "-b", branch], { cwd: targetDir });
+    await exec("git", ["checkout", "-b", branch], { cwd: targetDir, verbose: opts.verbose });
   }
 }
 


### PR DESCRIPTION
Adds two features from #040:

- `-v/--verbose` global flag: prints each git command and its output (dimmed) for diagnostics
- `-- <git-args>` passthrough: args after `--` are forwarded to the underlying `git worktree add/remove` command

Closes #40

Generated with [Claude Code](https://claude.ai/code)