### PR TITLE
feat: require remote in forest marker, stop discovery at $HOME

### DIFF
--- a/openspec/changes/bound-forest-root-discovery/.openspec.yaml
+++ b/openspec/changes/bound-forest-root-discovery/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-09

--- a/openspec/changes/bound-forest-root-discovery/design.md
+++ b/openspec/changes/bound-forest-root-discovery/design.md
@@ -1,0 +1,104 @@
+## Context
+
+`findForestRoot` currently looks for any file named `.workforest.yaml` walking up from cwd. The same filename is reused as the global config file at `~/.workforest.yaml`. When no closer marker exists, traversal reaches `$HOME`, matches the global config, and `findTrees` then recursively scans the entire home directory spawning a `git branch --show-current` subprocess per entry. Observed real-world impact: `git forest list` takes tens of seconds in an unrelated repo.
+
+The root cause is conflation: one filename is being asked to serve two unrelated roles (global config vs forest marker). Research into other tools (git, cargo, find-up) confirmed there is no single convention — git uses filesystem-device boundaries, cargo stops at `CARGO_HOME`, find-up walks to `/` by default. We want a simpler, content-based distinction plus a `$HOME` guardrail.
+
+We also want the forest marker to be more than a sentinel: it should carry the minimum information required to rebuild the forest from an empty directory, which is the git remote URL.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix the home-directory scan bug so `git forest list` is fast regardless of where it is run.
+- Make the forest marker self-describing enough to recreate the forest via a future `git forest clone`-from-marker flow.
+- Keep a single config filename (`.workforest.yaml`) — no new file types.
+- Give users a clear, actionable error when they hit the legacy case.
+
+**Non-Goals:**
+- Implementing the recreation command itself (separate change).
+- Changing the global config schema beyond adding the optional `remote` key.
+- Supporting multiple remotes per forest.
+- Changing how individual worktrees are discovered inside a forest (still `findTrees`).
+
+## Decisions
+
+### Decision 1: distinguish forest marker from config by content, not filename
+
+A `.workforest.yaml` file is a forest marker **if and only if** it contains a top-level `remote:` key with a non-empty string value. Otherwise it is global or local config and is ignored by `findForestRoot`.
+
+**Alternatives considered:**
+- Separate filename (e.g. `.workforest` sentinel or `forest.yaml`). Rejected: adds a second file type, complicates docs and discovery.
+- Explicit `forest: true` boolean. Rejected: carries no useful information; `remote:` doubles as the recreation recipe.
+- Directory-based marker (`.workforest/`). Rejected: heavier than a single file, no benefit.
+
+**Rationale:** one filename, unambiguous schema, and the marker key is load-bearing — it documents the forest's identity and enables future recreation.
+
+### Decision 2: `remote:` is the minimum viable forest state
+
+The only field required to reconstruct a forest from an empty container directory is the git remote URL. Everything else is derivable:
+- `org`/`repo`/`provider` → parsed from the URL (existing `getRepoName` logic).
+- default branch → `git symbolic-ref refs/remotes/origin/HEAD` after clone.
+- tree layout → global `treeDir` pattern.
+- individual trees → user re-adds via `git forest add` or a future `git forest restore`.
+
+### Decision 3: halt traversal at `$HOME`
+
+`findForestRoot` stops walking once `dir === os.homedir()`. If a `.workforest.yaml` containing `remote:` is found **at** `$HOME` or `/`, it is refused with a clear error rather than accepted — those locations are never valid forest roots.
+
+**Alternatives considered:**
+- git-style `st_dev` filesystem-boundary check. Good but doesn't address the actual bug (the home config file). We can layer this in later if needed.
+- `GIT_CEILING_DIRECTORIES`-style env var. Overkill for the real problem.
+
+### Decision 4: migration is manual, with a helpful error
+
+When discovery finds a `.workforest.yaml` without `remote:` in a plausible forest location (i.e. not `$HOME`), it treats the file as legacy and errors with the exact line to add:
+
+```
+error: forest marker at <path> is missing the 'remote:' key.
+
+# add the remote url to the forest marker:
+echo 'remote: <git-url>' >> <path>
+```
+
+Auto-migration is rejected because the tool cannot reliably infer the remote URL without inspecting a child worktree, and silent file rewrites are surprising.
+
+### Decision 5: `init`, `clone`, `migrate` write `remote:`
+
+These commands already know the remote URL at creation time, so they SHALL write a forest-level `.workforest.yaml` containing at minimum:
+
+```yaml
+remote: git@github.com:<org>/<repo>.git
+```
+
+`migrate` reads `git remote get-url origin` from the existing repo it is adopting.
+
+### Decision 6: `findForestRoot` returns the remote URL alongside the path
+
+`findForestRoot` returns `{ forestRoot: string, remote: string }` instead of just `string | null`. This makes the marker's remote available to all callers without re-reading the file.
+
+### Decision 7: commands use the marker's remote, not a child tree's origin
+
+`checkoutCommand` (backing `git forest add`) reads origin from the marker's `remote:` value. In fatTrees mode, `gitFatClone` receives this URL directly instead of inferring it from `trees[0]`. This prevents wrong-repo clones when unrelated repos (e.g. `scratch/ark`) exist in the forest directory.
+
+### Decision 8: `findTrees` filters by remote and skips `scratch/`
+
+`scratch/` is added to `SKIP_DIRS` alongside `node_modules`, `.git`, `.worktrees`. Additionally, `findTrees` compares each discovered tree's `origin` URL against the marker's `remote:` and excludes non-matching trees from the listing. URL comparison normalises trailing `.git` and protocol differences (ssh vs https) to avoid false negatives.
+
+## Risks / Trade-offs
+
+- **Breaking change for existing forests.** → Clear error message with exact fix command; documented in CHANGELOG.
+- **Users with `remote:` accidentally in `~/.workforest.yaml`.** → The `$HOME` guard refuses it and prints a specific error ("refusing to treat $HOME as a forest root; remove the 'remote:' key from ~/.workforest.yaml").
+- **Repos with multiple remotes.** → We persist the `origin` URL only. Non-goal for this change; can extend later.
+- **URL drift** (user changes remote after forest creation). → `.workforest.yaml` becomes stale. Accepted; future `git forest doctor` could reconcile.
+
+## Migration Plan
+
+1. Ship the new discovery behaviour alongside `init`/`clone`/`migrate` writing `remote:`.
+2. On first run in a legacy forest, users see the explicit error and add the key (one line).
+3. Document in CHANGELOG and README under a "Breaking changes" heading.
+4. No rollback needed: the legacy file format is a strict subset (empty or config-only `.workforest.yaml`), so reverting the code makes old forests work again.
+
+## Resolved Questions
+
+- **Derive only.** Only `remote:` is persisted. `provider`/`org`/`repo` are parsed on demand via the existing `getRepoName` logic. Keeps the file minimal and avoids drift.
+- **No `st_dev` check.** Not needed — the `$HOME` guard addresses the real bug. Revisit only if a concrete mount-point case appears.

--- a/openspec/changes/bound-forest-root-discovery/proposal.md
+++ b/openspec/changes/bound-forest-root-discovery/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+`findForestRoot` walks up from cwd looking for any `.workforest.yaml`, but that same filename is also the global config file at `~/.workforest.yaml`. If a user runs `git forest list` from a directory with no closer marker, discovery walks up to `$HOME`, treats the global config as a forest root, and then recursively scans the entire home directory spawning a `git` subprocess per subdirectory — catastrophically slow and wrong.
+
+The fix is to distinguish a forest marker from global config by content, not by filename, and to require the marker to carry the minimum information needed to recreate the forest from scratch: the remote URL.
+
+## What Changes
+
+- **BREAKING**: a `.workforest.yaml` file is only treated as a forest root marker if it contains a `remote:` key with the git remote URL. A file with only global-config keys (`reposDir`, `treeDir`, `fatTrees`, `verbose`) is ignored by `findForestRoot`.
+- New required field in the forest-level `.workforest.yaml`: `remote: <git-url>`. This is the minimum needed to recreate the forest (`git clone <remote>` rebuilds the default tree; further trees come from `git worktree add`).
+- `findForestRoot` stops traversal at `$HOME` and refuses to treat `$HOME` or `/` as a forest root even if a marker is present there. A clear error points the user at the likely cause (global config file conflict).
+- `git forest init` / `git forest clone` / `git forest migrate` write the `remote:` key into the forest-level `.workforest.yaml` when creating or adopting a forest.
+- Migration path for existing forests: discovery prints a clear error when it finds an empty/legacy `.workforest.yaml` without `remote:`, telling the user to run `git forest migrate` (or add the key manually) to upgrade.
+- Unlocks a future `git forest clone` behaviour: given an empty directory containing only a `.workforest.yaml` with `remote:`, the tool can reconstruct the forest end-to-end.
+- `findTrees` uses the marker's `remote:` as the authoritative origin URL. Commands that need the origin (e.g. `add` in fatTrees mode) read it from the marker instead of sniffing a child tree. Trees whose origin does not match the marker's `remote:` are excluded from listings.
+- `scratch/` is added to the skip list in `findTrees` alongside `node_modules`, `.git`, `.worktrees`.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `forest-detection`: `findForestRoot` now requires the `remote:` key to accept a file as a forest marker, and halts traversal at `$HOME`. Returns the `remote` URL alongside the root path.
+- `config`: documents the distinction between global config (`~/.workforest.yaml`, no `remote:`) and forest-level config (contains `remote:`). Adds the `remote` field to the schema as optional at the global level, required at the forest level.
+- `list-command`: trees whose origin does not match the forest `remote:` are excluded from listings.
+- `add-command`: reads origin URL from the forest marker's `remote:`, not from a child tree. Fixes wrong-repo clones when stray repos exist in the forest.
+- `init-command`, `clone-command`, `migrate-command`: these commands SHALL write `remote:` into the forest-level `.workforest.yaml` they create.
+
+## Impact
+
+- Code: `src/paths.ts` (findForestRoot returns remote), `src/config.ts` (schema adds `remote`), `src/commands/status.ts` (filter trees by remote, skip `scratch/`), `src/commands/checkout.ts` (use marker remote), `src/commands/clone.ts`, `src/commands/migrate.ts` (all write `remote:`).
+- Existing forests on disk: users must upgrade their forest marker. A clear error with a one-line fix is shown.
+- No new dependencies.

--- a/openspec/changes/bound-forest-root-discovery/specs/add-command/spec.md
+++ b/openspec/changes/bound-forest-root-discovery/specs/add-command/spec.md
@@ -1,0 +1,17 @@
+## MODIFIED Requirements
+
+### Requirement: add command resolves git root from any tree
+When invoked from the forest root (which is itself not a git repo), the CLI SHALL use the forest marker's `remote:` URL as the authoritative origin. In fatTrees mode, `gitFatClone` SHALL receive this URL directly instead of reading `origin` from a child tree.
+
+#### Scenario: invoked from forest root
+- **WHEN** user runs `git forest add <branch>` from the forest root and the forest contains at least one tree
+- **THEN** the CLI SHALL use that tree's git directory to run `git worktree add`
+- **AND** SHALL succeed
+
+#### Scenario: invoked from forest root in fatTrees mode
+- **WHEN** user runs `git forest add <branch>` from the forest root with `fatTrees: true`
+- **THEN** the CLI SHALL clone from the forest marker's `remote:` URL, not from a child tree's `origin`
+
+#### Scenario: invoked from forest root, no trees exist
+- **WHEN** user runs `git forest add <branch>` from a forest with no trees
+- **THEN** the CLI SHALL fail with `no git trees found in forest. try 'git forest clone <org/repo>' to add a repo`

--- a/openspec/changes/bound-forest-root-discovery/specs/clone-command/spec.md
+++ b/openspec/changes/bound-forest-root-discovery/specs/clone-command/spec.md
@@ -1,0 +1,8 @@
+## MODIFIED Requirements
+
+### Requirement: clone creates forest structure
+The CLI SHALL clone the repo, detect the default branch, place the clone in a subfolder named after the default branch, and write a `.workforest.yaml` marker containing the git remote URL.
+
+#### Scenario: successful clone
+- **WHEN** clone completes
+- **THEN** the forest root SHALL contain a `.workforest.yaml` file with a top-level `remote:` key set to the git remote URL, and a subdirectory named after the default branch containing the cloned repo

--- a/openspec/changes/bound-forest-root-discovery/specs/config/spec.md
+++ b/openspec/changes/bound-forest-root-discovery/specs/config/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: config supports optional remote field
+The config schema SHALL include an optional `remote` field of type string. The presence of this field at a file's top level distinguishes a forest-level `.workforest.yaml` (which has `remote:`) from the global config file at `~/.workforest.yaml` (which does not).
+
+#### Scenario: global config without remote
+- **WHEN** `~/.workforest.yaml` contains `reposDir`, `treeDir`, or other config fields but no `remote:`
+- **THEN** the CLI SHALL load it as global config and SHALL NOT treat it as a forest marker
+
+#### Scenario: forest-level config with remote
+- **WHEN** a `.workforest.yaml` at a forest root contains `remote: <url>`
+- **THEN** the CLI SHALL parse the remote URL and use it as the forest's identity
+
+#### Scenario: invalid remote type
+- **WHEN** `remote:` is present but is not a non-empty string
+- **THEN** zod validation SHALL reject the file at load time

--- a/openspec/changes/bound-forest-root-discovery/specs/forest-detection/spec.md
+++ b/openspec/changes/bound-forest-root-discovery/specs/forest-detection/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: find forest root by marker file
+The CLI SHALL walk up the directory tree from a starting directory looking for a `.workforest.yaml` file that contains a top-level `remote:` key with a non-empty string value. A `.workforest.yaml` file without a `remote:` key SHALL NOT be treated as a forest marker. Traversal SHALL halt at the user's home directory (`$HOME`) — neither `$HOME` nor the filesystem root SHALL ever be treated as a forest root, even if a qualifying marker file is present there.
+
+#### Scenario: marker with remote found
+- **WHEN** a `.workforest.yaml` file containing `remote: <url>` exists in an ancestor directory below `$HOME`
+- **THEN** `findForestRoot` SHALL return the path of that directory
+
+#### Scenario: marker without remote is ignored
+- **WHEN** a `.workforest.yaml` file exists in an ancestor directory but does not contain a `remote:` key
+- **THEN** `findForestRoot` SHALL skip it and continue walking upward
+
+#### Scenario: traversal halts at home
+- **WHEN** traversal reaches `$HOME` without finding a qualifying marker
+- **THEN** `findForestRoot` SHALL return `null` without inspecting `$HOME` or any ancestor of `$HOME`
+
+#### Scenario: marker at $HOME is refused
+- **WHEN** a `.workforest.yaml` at `$HOME` contains a `remote:` key
+- **THEN** `findForestRoot` SHALL throw an error stating that `$HOME` cannot be a forest root and instructing the user to remove `remote:` from `~/.workforest.yaml`
+
+#### Scenario: legacy marker without remote below home
+- **WHEN** a `.workforest.yaml` without `remote:` is found in a plausible forest location (not `$HOME`) and no qualifying marker exists
+- **THEN** `findForestRoot` SHALL throw an error identifying the legacy file and instructing the user to add a `remote:` key

--- a/openspec/changes/bound-forest-root-discovery/specs/init-command/spec.md
+++ b/openspec/changes/bound-forest-root-discovery/specs/init-command/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: init command detects context and acts accordingly
+The CLI SHALL provide an `init` command that detects whether the current working directory is inside a forest, inside a non-forest git repo, or neither, and SHALL take the most useful action for that context. When `init` creates or adopts a forest (via migration), it SHALL write a `.workforest.yaml` marker containing `remote:` set to the repo's `origin` URL.
+
+#### Scenario: already a forest
+- **WHEN** user runs `git forest init` from inside a workforest
+- **THEN** the CLI SHALL print `already a forest. on branch <branch> in <org/repo>` (or `already a forest. in <org/repo>` if not inside a tree)
+- **AND** SHALL print the tree listing in the same format as `git forest list`
+
+#### Scenario: forest with no trees
+- **WHEN** user runs `git forest init` from a directory containing a forest-level `.workforest.yaml` but no trees
+- **THEN** the CLI SHALL print `forest detected, no trees found.`
+
+#### Scenario: existing repo, not yet a forest
+- **WHEN** user runs `git forest init` from inside a git repo that has no forest-level `.workforest.yaml` ancestor
+- **THEN** the CLI SHALL print a migration preview showing the proposed forest layout with current local branches
+- **AND** SHALL prompt `migrate to forest layout? (y/N)`
+- **AND** on confirmation SHALL run the migration, write `remote:` into the new marker, and print `migrated to forest layout.` followed by a `cd` hint
+- **AND** on rejection SHALL print `aborted.`
+
+#### Scenario: empty directory, no repo
+- **WHEN** user runs `git forest init` from a directory that is neither a forest nor a git repo
+- **THEN** the CLI SHALL print `no forest found. clone one with:` followed by example `git forest clone` commands

--- a/openspec/changes/bound-forest-root-discovery/specs/list-command/spec.md
+++ b/openspec/changes/bound-forest-root-discovery/specs/list-command/spec.md
@@ -1,0 +1,17 @@
+## MODIFIED Requirements
+
+### Requirement: list command discovers nested trees
+The CLI SHALL recurse into directories under the forest root to find trees whose branch name contains `/` (e.g. `feat/dark-mode` stored at `<forest-root>/feat/dark-mode`).
+
+#### Scenario: nested tree exists
+- **WHEN** the forest contains `<forest-root>/feat/dark-mode/` as a worktree
+- **THEN** `git forest list` SHALL include `feat/dark-mode` in its output
+- **AND** the path column SHALL show `./feat/dark-mode`
+
+#### Scenario: skip directories
+- **WHEN** scanning the forest root, directories named `node_modules`, `.git`, `.worktrees`, or `scratch` exist
+- **THEN** the CLI SHALL NOT recurse into them
+
+#### Scenario: tree with non-matching remote is excluded
+- **WHEN** a subdirectory is a git repo whose `origin` remote does not match the forest marker's `remote:` URL
+- **THEN** the CLI SHALL exclude it from the tree listing

--- a/openspec/changes/bound-forest-root-discovery/specs/migrate-command/spec.md
+++ b/openspec/changes/bound-forest-root-discovery/specs/migrate-command/spec.md
@@ -1,0 +1,12 @@
+## MODIFIED Requirements
+
+### Requirement: migrate converts existing repo to forest layout
+The CLI SHALL move the existing repo into a subdirectory named after the current branch and create a `.workforest.yaml` marker containing the git remote URL read from `origin`.
+
+#### Scenario: successful migration
+- **WHEN** user confirms migration
+- **THEN** the repo SHALL be moved to `<original-path>/<branch>/` and a `.workforest.yaml` marker SHALL be created at the original path containing `remote: <origin-url>`
+
+#### Scenario: repo has no origin remote
+- **WHEN** the repo being migrated has no `origin` remote configured
+- **THEN** the CLI SHALL print an error asking the user to set `origin` before migrating

--- a/openspec/changes/bound-forest-root-discovery/tasks.md
+++ b/openspec/changes/bound-forest-root-discovery/tasks.md
@@ -1,0 +1,47 @@
+## Tasks
+
+### Task 1: Update config schema to support `remote` field
+- File: `src/config.ts`
+- Add optional `remote` field (string) to `ConfigSchema`
+- Add `parseRemoteFromYaml(filePath)` helper that reads a yaml file and returns the `remote` value or `null`
+
+### Task 2: Update `findForestRoot` to require `remote:` and stop at `$HOME`
+- File: `src/paths.ts`
+- Change return type to `Promise<{ forestRoot: string; remote: string } | null>`
+- Read yaml at each candidate, skip files without `remote:` key
+- Stop traversal at `os.homedir()` — refuse to treat `$HOME` or `/` as forest root
+- If marker at `$HOME` has `remote:`, throw error with clear message
+- If legacy marker (no `remote:`) found below `$HOME`, throw error with upgrade instructions
+
+### Task 3: Add `normaliseRemoteUrl` helper and filter trees by remote
+- File: `src/git.ts` (helper), `src/commands/status.ts` (filtering)
+- Add `normaliseRemoteUrl(url)` that strips `.git` suffix and normalises `git@github.com:org/repo` to `github.com/org/repo` for comparison
+- Add `scratch` to `SKIP_DIRS`
+- After discovering trees, filter out those whose `origin` URL doesn't match the forest's `remote:` (using normalised comparison)
+- `statusTrees` accepts the forest `remote` and passes it through
+
+### Task 4: Update `checkoutCommand` to use marker remote
+- File: `src/commands/checkout.ts`
+- Accept forest `remote` from `findForestRoot` result
+- In fatTrees mode, pass `remote` directly to `gitFatClone` instead of inferring from `trees[0]`
+- Update `gitFatClone` signature to accept explicit `remoteUrl` parameter (optional, falls back to reading origin if not provided)
+
+### Task 5: Write `remote:` in `clone` and `migrate`
+- Files: `src/commands/clone.ts`, `src/commands/migrate.ts`
+- `cloneCommand`: write `remote: <repoUrl>` into `.workforest.yaml` instead of empty string
+- `migrateToForest`: read `git remote get-url origin`, write `remote: <url>` into `.workforest.yaml`
+
+### Task 6: Update all callers of `findForestRoot`
+- Files: `src/cli.ts`, `src/commands/migrate.ts` (detectContext), `src/commands/remove.ts`
+- Adapt to new return type `{ forestRoot, remote } | null`
+- Pass `remote` through where needed (e.g. `statusTrees`, `checkoutCommand`)
+
+### Task 7: Update `getRepoName` in CLI to use marker remote
+- File: `src/cli.ts`
+- `runStatus` and `init` currently call `getRepoName(trees[0].path)` — change to parse org/repo from the marker's `remote` URL directly
+
+### Task 8: Update tests
+- Update `status.test.ts`, `checkout.test.ts`, `clone.test.ts`, `migrate.test.ts`
+- Ensure test forests have `remote:` in their `.workforest.yaml`
+- Add test for `findForestRoot` rejecting files without `remote:`
+- Add test for `normaliseRemoteUrl` matching

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,7 +15,6 @@ import readline from "readline/promises";
 import chalk from "chalk";
 import path from "path";
 import { statusTrees, formatTreeLine } from "./commands/status.js";
-import { getRepoName } from "./git.js";
 
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json");
@@ -222,16 +221,12 @@ program
       const context = await detectContext(process.cwd());
 
       if (context === "forest") {
-        const { forestRoot, trees } = await statusTrees(process.cwd());
+        const { forestRoot, repoName, trees } = await statusTrees(process.cwd());
         if (trees.length === 0) {
           console.log("forest detected, no trees found.");
           return;
         }
         const activeTree = trees.find((t) => t.active);
-        const repoName = await getRepoName(
-          trees[0].path,
-          path.basename(forestRoot),
-        );
         if (activeTree) {
           console.log(`already a forest. on branch ${chalk.green(activeTree.branch)} in ${chalk.whiteBright(repoName)}`);
         } else {
@@ -287,14 +282,13 @@ program
 
 async function runStatus(): Promise<void> {
   try {
-    const { forestRoot, trees } = await statusTrees(process.cwd());
+    const { forestRoot, repoName, trees } = await statusTrees(process.cwd());
     if (trees.length === 0) {
       console.log("no trees found.");
       return;
     }
 
     const activeTree = trees.find((t) => t.active);
-    const repoName = await getRepoName(trees[0].path, path.basename(forestRoot));
     if (activeTree) {
       console.log(`on branch ${chalk.green(activeTree.branch)} in ${chalk.whiteBright(repoName)}`);
     } else {

--- a/src/commands/checkout.test.ts
+++ b/src/commands/checkout.test.ts
@@ -29,7 +29,7 @@ describe("checkout command", () => {
     );
     await fs.mkdir(repoRoot, { recursive: true });
     execSync(`git clone "${bareRepo}" "${mainDir}"`, quiet);
-    await fs.writeFile(path.join(repoRoot, ".workforest.yaml"), "");
+    await fs.writeFile(path.join(repoRoot, ".workforest.yaml"), `remote: ${bareRepo}\n`);
   });
 
   afterEach(async () => {

--- a/src/commands/checkout.ts
+++ b/src/commands/checkout.ts
@@ -17,13 +17,14 @@ export async function checkoutCommand(
   extraArgs: string[] = [],
   opts: GitOptions = {},
 ): Promise<CheckoutResult> {
-  const forestRoot = await findForestRoot(cwd);
-  if (!forestRoot) {
+  const result = await findForestRoot(cwd);
+  if (!result) {
     throw new Error(
       "not inside a workforest.\ntry 'git forest clone <org/repo>' or 'git forest migrate'",
     );
   }
 
+  const { forestRoot, remote } = result;
   const { trees } = await statusTrees(cwd);
   const match = trees.find((t) => t.branch === branch || t.name === branch);
   if (match) {
@@ -46,7 +47,7 @@ export async function checkoutCommand(
   const treePath = resolveTreePath(forestRoot, config.treeDir, branch);
 
   if (config.fatTrees) {
-    await gitFatClone(gitRoot, treePath, branch, opts);
+    await gitFatClone(gitRoot, treePath, branch, { ...opts, remoteUrl: remote });
   } else {
     await gitWorktreeAdd(gitRoot, treePath, branch, extraArgs, opts);
   }

--- a/src/commands/clone.ts
+++ b/src/commands/clone.ts
@@ -33,7 +33,7 @@ export async function cloneCommand(
 
   await fs.rename(tmpClone, treePath);
 
-  await fs.writeFile(path.join(repoRoot, ".workforest.yaml"), "");
+  await fs.writeFile(path.join(repoRoot, ".workforest.yaml"), `remote: ${repoUrl}\n`);
 
   return { repoRoot, treePath, branch: defaultBranch };
 }

--- a/src/commands/migrate.test.ts
+++ b/src/commands/migrate.test.ts
@@ -35,7 +35,7 @@ describe("migrate command", () => {
     it("returns 'forest' when .workforest.yaml exists", async () => {
       const forestDir = path.join(tmpDir, "myforest");
       await fs.mkdir(forestDir);
-      await fs.writeFile(path.join(forestDir, ".workforest.yaml"), "");
+      await fs.writeFile(path.join(forestDir, ".workforest.yaml"), "remote: git@github.com:test/repo.git\n");
       expect(await detectContext(forestDir)).toBe("forest");
     });
   });
@@ -95,7 +95,7 @@ describe("migrate command", () => {
       const repoDir = path.join(tmpDir, "myrepo");
       execSync(`git init "${repoDir}"`, quiet);
       execSync(
-        `cd "${repoDir}" && git config user.email "test@test.com" && git config user.name "Test" && git config commit.gpgsign false && touch README.md && git add . && git commit -m "init"`,
+        `cd "${repoDir}" && git config user.email "test@test.com" && git config user.name "Test" && git config commit.gpgsign false && touch README.md && git add . && git commit -m "init" && git remote add origin git@github.com:test/repo.git`,
         quiet,
       );
 
@@ -110,7 +110,7 @@ describe("migrate command", () => {
       const repoDir = path.join(tmpDir, "slashrepo");
       execSync(`git init "${repoDir}"`, quiet);
       execSync(
-        `cd "${repoDir}" && git config user.email "test@test.com" && git config user.name "Test" && git config commit.gpgsign false && touch README.md && git add . && git commit -m "init" && git checkout -b feat/my-feature`,
+        `cd "${repoDir}" && git config user.email "test@test.com" && git config user.name "Test" && git config commit.gpgsign false && touch README.md && git add . && git commit -m "init" && git remote add origin git@github.com:test/repo.git && git checkout -b feat/my-feature`,
         quiet,
       );
 
@@ -124,18 +124,18 @@ describe("migrate command", () => {
       expect(readmeStat.isFile()).toBe(true);
     });
 
-    it("creates .workforest.yaml marker after migration", async () => {
+    it("creates .workforest.yaml marker with remote after migration", async () => {
       const repoDir = path.join(tmpDir, "myrepo");
       execSync(`git init "${repoDir}"`, quiet);
       execSync(
-        `cd "${repoDir}" && git config user.email "test@test.com" && git config user.name "Test" && git config commit.gpgsign false && touch README.md && git add . && git commit -m "init"`,
+        `cd "${repoDir}" && git config user.email "test@test.com" && git config user.name "Test" && git config commit.gpgsign false && touch README.md && git add . && git commit -m "init" && git remote add origin git@github.com:test/repo.git`,
         quiet,
       );
 
       const result = await migrateToForest(repoDir);
       const marker = path.join(result.repoRoot, ".workforest.yaml");
-      const stat = await fs.stat(marker);
-      expect(stat.isFile()).toBe(true);
+      const content = await fs.readFile(marker, "utf-8");
+      expect(content).toContain("remote: git@github.com:test/repo.git");
     });
   });
 });

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import { promises as fs } from "fs";
-import { getRepoRoot, getLocalBranch, isInsideWorktree } from "../git.js";
+import { getRepoRoot, getLocalBranch, isInsideWorktree, gitExec } from "../git.js";
 import { findForestRoot } from "../paths.js";
 
 export interface MigrateResult {
@@ -12,7 +12,12 @@ export interface MigrateResult {
 export async function detectContext(
   cwd: string,
 ): Promise<"forest" | "repo" | "empty"> {
-  if (await findForestRoot(cwd)) return "forest";
+  try {
+    if (await findForestRoot(cwd)) return "forest";
+  } catch {
+    // Legacy marker errors — treat as forest needing upgrade
+    return "forest";
+  }
   if (await isInsideWorktree(cwd)) return "repo";
   return "empty";
 }
@@ -56,6 +61,13 @@ export async function migrateToForest(cwd: string): Promise<MigrateResult> {
   const repoRoot = gitRoot;
   const treePath = path.join(repoRoot, branch);
 
+  // Read origin URL before moving files
+  const { stdout } = await gitExec("git", ["remote", "get-url", "origin"], { cwd: gitRoot });
+  const remoteUrl = stdout.trim();
+  if (!remoteUrl) {
+    throw new Error("repo has no 'origin' remote. set one before migrating:\n  git remote add origin <url>");
+  }
+
   // Stage everything into a temp dir first so that mkdir for branch paths
   // containing '/' (e.g. feat/foo) won't collide with existing entries.
   const staging = path.join(repoRoot, `.workforest-migrate-${Date.now()}`);
@@ -81,7 +93,7 @@ export async function migrateToForest(cwd: string): Promise<MigrateResult> {
   }
 
   await fs.rm(staging, { recursive: true });
-  await fs.writeFile(path.join(repoRoot, ".workforest.yaml"), "");
+  await fs.writeFile(path.join(repoRoot, ".workforest.yaml"), `remote: ${remoteUrl}\n`);
 
   return { repoRoot, treePath, branch };
 }

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -12,12 +12,7 @@ export interface MigrateResult {
 export async function detectContext(
   cwd: string,
 ): Promise<"forest" | "repo" | "empty"> {
-  try {
-    if (await findForestRoot(cwd)) return "forest";
-  } catch {
-    // Legacy marker errors — treat as forest needing upgrade
-    return "forest";
-  }
+  if (await findForestRoot(cwd)) return "forest";
   if (await isInsideWorktree(cwd)) return "repo";
   return "empty";
 }

--- a/src/commands/remove.test.ts
+++ b/src/commands/remove.test.ts
@@ -30,7 +30,7 @@ describe("remove command", () => {
       `cd "${mainDir}" && git worktree add -b fix-typo "${path.join(repoRoot, "fix-typo")}" HEAD`,
       quiet,
     );
-    await fs.writeFile(path.join(repoRoot, ".workforest.yaml"), "");
+    await fs.writeFile(path.join(repoRoot, ".workforest.yaml"), `remote: ${bareRepo}\n`);
   });
 
   afterEach(async () => {

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -17,13 +17,14 @@ export async function removeCommand(
   extraArgs: string[] = [],
   opts: GitOptions = {},
 ): Promise<RemoveResult> {
-  const forestRoot = await findForestRoot(cwd);
-  if (!forestRoot) {
+  const result = await findForestRoot(cwd);
+  if (!result) {
     throw new Error(
       "not inside a workforest.\ntry 'git forest clone <org/repo>' or 'git forest migrate'",
     );
   }
 
+  const { forestRoot } = result;
   const { trees } = await statusTrees(cwd);
   const match = trees.find((t) => t.branch === branch || t.name === branch);
   if (!match) {

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -27,7 +27,7 @@ describe("status command", () => {
       `cd "${path.join(repoRoot, "main")}" && git worktree add -b fix-typo "${path.join(repoRoot, "fix-typo")}" HEAD`,
       quiet,
     );
-    await fs.writeFile(path.join(repoRoot, ".workforest.yaml"), "");
+    await fs.writeFile(path.join(repoRoot, ".workforest.yaml"), `remote: ${bareRepo}\n`);
   });
 
   afterEach(async () => {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -33,7 +33,7 @@ export interface ForestStatus {
   trees: TreeEntry[];
 }
 
-const SKIP_DIRS = new Set(["node_modules", ".git", ".worktrees", "scratch"]);
+const SKIP_DIRS = new Set(["node_modules", ".git", ".worktrees"]);
 
 async function getOriginUrl(dir: string): Promise<string | null> {
   try {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from "fs";
 import path from "path";
 import { findForestRoot } from "../paths.js";
+import { remoteUrlsMatch, repoNameFromRemote } from "../git.js";
 import { execFile } from "child_process";
 
 function exec(
@@ -26,16 +27,28 @@ export interface TreeEntry {
 
 export interface ForestStatus {
   forestRoot: string;
+  remote: string;
+  repoName: string;
   defaultBranch: string | null;
   trees: TreeEntry[];
 }
 
-const SKIP_DIRS = new Set(["node_modules", ".git", ".worktrees"]);
+const SKIP_DIRS = new Set(["node_modules", ".git", ".worktrees", "scratch"]);
+
+async function getOriginUrl(dir: string): Promise<string | null> {
+  try {
+    const { stdout } = await exec("git", ["config", "remote.origin.url"], { cwd: dir });
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
 
 async function findTrees(
   dir: string,
   forestRoot: string,
   resolvedCwd: string,
+  forestRemote: string | null,
 ): Promise<TreeEntry[]> {
   const entries = await fs.readdir(dir, { withFileTypes: true });
   const trees: TreeEntry[] = [];
@@ -53,6 +66,13 @@ async function findTrees(
       );
       const branch = stdout.trim();
       if (branch) {
+        // Filter out trees whose origin doesn't match the forest remote
+        if (forestRemote) {
+          const treeOrigin = await getOriginUrl(entryPath);
+          if (treeOrigin && !remoteUrlsMatch(treeOrigin, forestRemote)) {
+            continue;
+          }
+        }
         const active = resolvedCwd.startsWith(entryPath);
         trees.push({
           name: path.relative(forestRoot, entryPath),
@@ -67,7 +87,7 @@ async function findTrees(
       // Not a git directory — recurse into it
     }
 
-    const nested = await findTrees(entryPath, forestRoot, resolvedCwd);
+    const nested = await findTrees(entryPath, forestRoot, resolvedCwd, forestRemote);
     trees.push(...nested);
   }
 
@@ -99,15 +119,18 @@ function sortTrees(trees: TreeEntry[], defaultBranch: string | null): TreeEntry[
 }
 
 export async function statusTrees(cwd: string): Promise<ForestStatus> {
-  const forestRoot = await findForestRoot(cwd);
-  if (!forestRoot) {
+  const result = await findForestRoot(cwd);
+  if (!result) {
     throw new Error(
       "not inside a workforest.\ntry 'git forest clone <org/repo>' or 'git forest migrate'",
     );
   }
 
+  const { forestRoot, remote } = result;
   const resolvedCwd = path.resolve(cwd);
-  const trees = await findTrees(forestRoot, forestRoot, resolvedCwd);
+  const trees = await findTrees(forestRoot, forestRoot, resolvedCwd, remote);
+
+  const name = repoNameFromRemote(remote) || path.basename(forestRoot);
 
   // Detect default branch: git symbolic-ref, then fallback to main/master
   const firstTree = trees[0];
@@ -123,7 +146,7 @@ export async function statusTrees(cwd: string): Promise<ForestStatus> {
 
   const sorted = sortTrees(trees, defaultBranch);
 
-  return { forestRoot, defaultBranch, trees: sorted };
+  return { forestRoot, remote, repoName: name, defaultBranch, trees: sorted };
 }
 
 export function formatTreeLine(tree: TreeEntry, forestRoot: string): string {

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ const ConfigSchema = z.object({
   treeDir: z.string().default("[branch]"),
   fatTrees: z.boolean().default(false),
   verbose: z.boolean().default(false),
+  remote: z.string().optional(),
 });
 
 export type WorkforestConfig = z.infer<typeof ConfigSchema>;

--- a/src/git.ts
+++ b/src/git.ts
@@ -81,19 +81,20 @@ export async function gitFatClone(
   sourceDir: string,
   targetDir: string,
   branch: string,
-  opts: GitOptions = {},
+  opts: GitOptions & { remoteUrl?: string } = {},
 ): Promise<void> {
-  const { stdout } = await exec("git", ["remote", "get-url", "origin"], {
-    cwd: sourceDir,
-    verbose: opts.verbose,
-  });
-  const originUrl = stdout.trim();
+  let originUrl = opts.remoteUrl;
+  if (!originUrl) {
+    const { stdout } = await exec("git", ["remote", "get-url", "origin"], {
+      cwd: sourceDir,
+      verbose: opts.verbose,
+    });
+    originUrl = stdout.trim();
+  }
   await exec("git", ["clone", originUrl, targetDir], { verbose: opts.verbose });
   try {
-    // Check out existing branch (local or remote tracking)
     await exec("git", ["checkout", branch], { cwd: targetDir, verbose: opts.verbose });
   } catch {
-    // Branch doesn't exist — create it
     await exec("git", ["checkout", "-b", branch], { cwd: targetDir, verbose: opts.verbose });
   }
 }
@@ -128,6 +129,23 @@ export async function listLocalBranches(repoDir: string): Promise<string[]> {
     { cwd: repoDir },
   );
   return stdout.trim().split("\n").filter(Boolean);
+}
+
+export function normaliseRemoteUrl(url: string): string {
+  return url
+    .replace(/\.git$/, "")
+    .replace(/^git@([^:]+):/, "https://$1/")
+    .replace(/^ssh:\/\/git@([^/]+)\//, "https://$1/")
+    .toLowerCase();
+}
+
+export function remoteUrlsMatch(a: string, b: string): boolean {
+  return normaliseRemoteUrl(a) === normaliseRemoteUrl(b);
+}
+
+export function repoNameFromRemote(url: string): string | null {
+  const match = url.match(/[/:]([^/]+\/[^/]+?)(?:\.git)?$/);
+  return match ? match[1] : null;
 }
 
 export async function getRepoRoot(dir: string): Promise<string> {

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -60,15 +60,27 @@ describe("paths", () => {
   });
 
   describe("findForestRoot", () => {
-    it("finds forest root by walking up to .workforest.yaml", async () => {
+    it("finds forest root by walking up to .workforest.yaml with remote", async () => {
       const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "wf-path-test-"));
       const forestRoot = path.join(tmpDir, "myrepo");
       const treeDir = path.join(forestRoot, "main", "src", "deep");
       await fs.mkdir(treeDir, { recursive: true });
-      await fs.writeFile(path.join(forestRoot, ".workforest.yaml"), "");
+      await fs.writeFile(path.join(forestRoot, ".workforest.yaml"), "remote: git@github.com:test/repo.git\n");
 
       const result = await findForestRoot(treeDir);
-      expect(result).toBe(forestRoot);
+      expect(result).toEqual({ forestRoot, remote: "git@github.com:test/repo.git" });
+
+      await fs.rm(tmpDir, { recursive: true });
+    });
+
+    it("throws for legacy marker without remote", async () => {
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "wf-path-test-"));
+      const forestRoot = path.join(tmpDir, "myrepo");
+      const treeDir = path.join(forestRoot, "main");
+      await fs.mkdir(treeDir, { recursive: true });
+      await fs.writeFile(path.join(forestRoot, ".workforest.yaml"), "");
+
+      await expect(findForestRoot(treeDir)).rejects.toThrow("missing the 'remote:' key");
 
       await fs.rm(tmpDir, { recursive: true });
     });

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -73,14 +73,15 @@ describe("paths", () => {
       await fs.rm(tmpDir, { recursive: true });
     });
 
-    it("throws for legacy marker without remote", async () => {
+    it("ignores marker without remote key", async () => {
       const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "wf-path-test-"));
       const forestRoot = path.join(tmpDir, "myrepo");
       const treeDir = path.join(forestRoot, "main");
       await fs.mkdir(treeDir, { recursive: true });
       await fs.writeFile(path.join(forestRoot, ".workforest.yaml"), "");
 
-      await expect(findForestRoot(treeDir)).rejects.toThrow("missing the 'remote:' key");
+      const result = await findForestRoot(treeDir);
+      expect(result).toBeNull();
 
       await fs.rm(tmpDir, { recursive: true });
     });

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -45,7 +45,6 @@ export async function findForestRoot(
   let dir = path.resolve(startDir);
   const root = path.parse(dir).root;
   const home = os.homedir();
-  let legacyMarker: string | null = null;
 
   while (dir !== root) {
     if (dir === home) break;
@@ -61,35 +60,11 @@ export async function findForestRoot(
       if (typeof remote === "string" && remote.length > 0) {
         return { forestRoot: dir, remote };
       }
-      // Legacy marker without remote — remember it for error reporting
-      if (!legacyMarker) legacyMarker = markerPath;
     } catch {
       // No file here — keep walking
     }
 
     dir = path.dirname(dir);
-  }
-
-  // Check for accidental marker at $HOME
-  try {
-    const homeMarker = path.join(home, ".workforest.yaml");
-    const content = await fs.readFile(homeMarker, "utf-8");
-    const parsed = parseYaml(content) ?? {};
-    if (typeof parsed === "object" && parsed !== null && "remote" in parsed) {
-      throw new Error(
-        `refusing to treat $HOME as a forest root. remove the 'remote:' key from ${homeMarker}`,
-      );
-    }
-  } catch (err) {
-    if (err instanceof Error && err.message.startsWith("refusing")) throw err;
-  }
-
-  if (legacyMarker) {
-    throw new Error(
-      `forest marker at ${legacyMarker} is missing the 'remote:' key.\n\n` +
-      `# add the remote url to the forest marker:\n` +
-      `echo 'remote: <git-url>' >> ${legacyMarker}`,
-    );
   }
 
   return null;

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,6 +1,7 @@
 import os from "os";
 import path from "path";
 import { promises as fs } from "fs";
+import { parse as parseYaml } from "yaml";
 
 export interface RepoTokens {
   provider: string;
@@ -33,19 +34,62 @@ export function resolveTreePath(
   return path.join(repoRoot, treeDir);
 }
 
+export interface ForestRoot {
+  forestRoot: string;
+  remote: string;
+}
+
 export async function findForestRoot(
   startDir: string,
-): Promise<string | null> {
+): Promise<ForestRoot | null> {
   let dir = path.resolve(startDir);
   const root = path.parse(dir).root;
+  const home = os.homedir();
+  let legacyMarker: string | null = null;
 
   while (dir !== root) {
+    if (dir === home) break;
+
+    const markerPath = path.join(dir, ".workforest.yaml");
     try {
-      await fs.access(path.join(dir, ".workforest.yaml"));
-      return dir;
+      const content = await fs.readFile(markerPath, "utf-8");
+      const parsed = parseYaml(content) ?? {};
+      const remote = typeof parsed === "object" && parsed !== null && "remote" in parsed
+        ? (parsed as Record<string, unknown>).remote
+        : undefined;
+
+      if (typeof remote === "string" && remote.length > 0) {
+        return { forestRoot: dir, remote };
+      }
+      // Legacy marker without remote — remember it for error reporting
+      if (!legacyMarker) legacyMarker = markerPath;
     } catch {
-      dir = path.dirname(dir);
+      // No file here — keep walking
     }
+
+    dir = path.dirname(dir);
+  }
+
+  // Check for accidental marker at $HOME
+  try {
+    const homeMarker = path.join(home, ".workforest.yaml");
+    const content = await fs.readFile(homeMarker, "utf-8");
+    const parsed = parseYaml(content) ?? {};
+    if (typeof parsed === "object" && parsed !== null && "remote" in parsed) {
+      throw new Error(
+        `refusing to treat $HOME as a forest root. remove the 'remote:' key from ${homeMarker}`,
+      );
+    }
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith("refusing")) throw err;
+  }
+
+  if (legacyMarker) {
+    throw new Error(
+      `forest marker at ${legacyMarker} is missing the 'remote:' key.\n\n` +
+      `# add the remote url to the forest marker:\n` +
+      `echo 'remote: <git-url>' >> ${legacyMarker}`,
+    );
   }
 
   return null;


### PR DESCRIPTION
## Summary
- `findForestRoot` now requires a `remote:` key in `.workforest.yaml` to treat it as a forest marker, fixing catastrophic slowness when `~/.workforest.yaml` (global config) was mistaken for a forest root
- Trees whose origin doesn't match the marker's `remote:` are excluded from listings, preventing wrong-repo clones from stray directories like `scratch/`
- `git forest add` in fatTrees mode uses the marker's `remote:` URL instead of inferring from child trees, fixing wrong-repo clone cascades
- `clone` and `migrate` now write `remote:` into the marker at creation time
- **BREAKING**: existing forests need `remote: <url>` added to their `.workforest.yaml`

OpenSpec change: `openspec/changes/bound-forest-root-discovery/`