### PR TITLE
fix: publish npm package as public

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,6 @@ jobs:
           registry-url: https://registry.npmjs.org
       - run: npm ci
       - run: npm run build
-      - run: npm publish --provenance --access restricted
+      - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Change npm publish access from `restricted` to `public`
- Private scoped packages require paid npm plan
- Package is already live at @dwmkerr/git-workforest@0.1.0 (published manually)
- NPM_TOKEN secret set in repo so auto-publish on future releases will work