### PR TITLE
fix: confirm respects default, migrate handles forest context

### DIFF
--- a/openspec/changes/fix-confirm-default-and-migrate-forest-context/.openspec.yaml
+++ b/openspec/changes/fix-confirm-default-and-migrate-forest-context/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-16

--- a/openspec/changes/fix-confirm-default-and-migrate-forest-context/design.md
+++ b/openspec/changes/fix-confirm-default-and-migrate-forest-context/design.md
@@ -1,0 +1,44 @@
+## Context
+
+Two small UX bugs:
+
+1. `confirm()` in `src/cli.ts` returns `true` for any input that isn't lowercase `"n"`. The helper takes no default — it treats empty input (just enter) as yes. The displayed prompts use the conventional `Y/n` (default yes) and `y/N` (default no) form, but the function ignores which default the prompt advertises.
+
+2. `migrate` in `src/cli.ts` branches on `context === "repo"` only. The else branch unconditionally prompts to clone, even when the user is already inside a forest.
+
+`init` already handles all three contexts correctly (forest/repo/empty) — `migrate` just needs to learn the same pattern.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Confirmation respects the displayed default.
+- `migrate` from inside a forest prints the tree listing, not a clone prompt.
+- No change to non-interactive flows (`-y` flags, scripted use).
+
+**Non-Goals:**
+- Changing the prompt text or colours.
+- Auto-cd after migrate (shells don't allow it).
+- Refactoring the three command handlers (`init`, `migrate`, `list`) into a shared context-dispatch — too much churn for two-line bug fixes.
+
+## Decisions
+
+### Decision 1: `confirm()` takes an explicit default
+
+```ts
+async function confirm(question: string, defaultYes: boolean): Promise<boolean>
+```
+
+Empty input returns `defaultYes`. Otherwise `y`/`yes` → true, `n`/`no` → false (case-insensitive). Anything else returns `defaultYes` (lenient — better than throwing on a typo).
+
+**Alternatives considered:**
+- Parse the prompt string for `Y/n` vs `y/N`. Rejected: implicit and brittle.
+- Return-type `"yes" | "no" | "default"` and let caller decide. Rejected: every caller would duplicate the same default-handling.
+
+### Decision 2: `migrate` handles forest context inline
+
+Add an `if (context === "forest")` branch in `migrate` that mirrors what `init` does for the same case (print "already a forest. on branch X in org/repo" and the tree list). Don't extract a shared helper yet — `init` and `migrate` have slightly different output surrounding the listing, and refactoring is out of scope.
+
+## Risks / Trade-offs
+
+- **Risk**: callers that pass a typo (e.g. `"yse"`) now silently get the default rather than treated as yes. → Acceptable; the only callers are interactive prompts where the user can re-run.
+- **Risk**: duplicated forest-context output between `init`, `migrate`, and `list`. → Accepted as future cleanup; flagged in non-goals.

--- a/openspec/changes/fix-confirm-default-and-migrate-forest-context/proposal.md
+++ b/openspec/changes/fix-confirm-default-and-migrate-forest-context/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Two related bugs in confirmation flow and command context handling:
+
+1. The `confirm()` helper treats any input other than `"n"` as confirmation — so pressing enter at a `(y/N)` prompt accepts the action even though the capital `N` signals the default should be no. Users hit this with `git forest migrate` and accidentally migrate when they meant to abort.
+
+2. The `migrate` command only handles two contexts (`"repo"` and `"empty"`). When run from inside an existing forest it falls into the else branch and incorrectly prompts to clone a new repo. It should detect "already in a forest" and print the tree listing, matching the behaviour of `init` and `list`.
+
+## What Changes
+
+- `confirm()` accepts a `defaultYes: boolean` parameter. Empty input returns the default. Existing call sites update accordingly:
+  - `clone` confirmation `(Y/n)` → `defaultYes: true` (unchanged behaviour)
+  - `migrate` confirmation `(y/N)` → `defaultYes: false` (fixes bug 1)
+- `migrate` command handles `context === "forest"` by printing "already a forest" and the tree listing, matching `init` (fixes bug 2).
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `migrate-command`: handles forest context (already a forest) by listing trees instead of prompting to clone.
+- `default-usage`: confirmation prompts respect their displayed default (`Y/n` defaults to yes, `y/N` defaults to no).
+
+## Impact
+
+- Code: `src/cli.ts` (confirm helper signature, migrate handler).
+- No new dependencies.
+- No behavioural change for `clone -y` or any non-interactive use.

--- a/openspec/changes/fix-confirm-default-and-migrate-forest-context/specs/migrate-command/spec.md
+++ b/openspec/changes/fix-confirm-default-and-migrate-forest-context/specs/migrate-command/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: migrate detects existing forest
+When the current directory is already inside a forest, `migrate` SHALL print "already a forest" and the tree listing instead of prompting to clone or migrate.
+
+#### Scenario: already in a forest
+- **WHEN** user runs `git forest migrate` from inside an existing forest
+- **THEN** the CLI SHALL print `already a forest. on branch <branch> in <org/repo>` (or `already a forest. in <org/repo>` if not inside a tree)
+- **AND** SHALL print the tree listing in the same format as `git forest list`
+- **AND** SHALL NOT prompt for migration or for an org/repo to clone
+
+## MODIFIED Requirements
+
+### Requirement: migrate detects context
+The CLI SHALL detect whether the current directory is inside a forest, inside a git repo, or empty, and SHALL take the appropriate action for each context.
+
+#### Scenario: inside a forest
+- **WHEN** user runs `workforest migrate` from inside an existing forest
+- **THEN** the CLI SHALL print "already a forest" with tree listing and SHALL NOT prompt to migrate or clone
+
+#### Scenario: inside a git repo
+- **WHEN** user runs `workforest migrate` inside a git repository that is not a forest
+- **THEN** the CLI SHALL offer to migrate the repo into forest layout
+
+#### Scenario: outside a git repo
+- **WHEN** user runs `workforest migrate` outside any git repository
+- **THEN** the CLI SHALL prompt for an `org/repo` to clone
+
+### Requirement: migrate requires confirmation
+The CLI SHALL ask for confirmation before migrating. The confirmation prompt SHALL appear after the before/after preview and SHALL default to no when the user provides empty input.
+
+#### Scenario: user declines explicitly
+- **WHEN** user responds with `n` or `no`
+- **THEN** the CLI SHALL print "aborted." and exit without changes
+
+#### Scenario: user accepts default by pressing enter
+- **WHEN** user presses enter without typing anything
+- **THEN** the CLI SHALL print "aborted." and exit without changes (the prompt's default is no)
+
+#### Scenario: user confirms explicitly
+- **WHEN** user responds with `y` or `yes`
+- **THEN** the CLI SHALL proceed with migration

--- a/openspec/changes/fix-confirm-default-and-migrate-forest-context/tasks.md
+++ b/openspec/changes/fix-confirm-default-and-migrate-forest-context/tasks.md
@@ -1,0 +1,24 @@
+## Tasks
+
+### Task 1: Update `confirm()` to accept an explicit default
+- File: `src/cli.ts`
+- Change signature: `confirm(question: string, defaultYes: boolean): Promise<boolean>`
+- Empty input → returns `defaultYes`
+- `y`/`yes` (case-insensitive) → `true`
+- `n`/`no` (case-insensitive) → `false`
+- Anything else → returns `defaultYes`
+
+### Task 2: Update call sites
+- File: `src/cli.ts`
+- Clone confirmation: `confirm("clone X to Y? (Y/n) ", true)`
+- Migrate confirmation (in `migrate` and `init`): `confirm("migrate to forest layout? (y/N) ", false)`
+
+### Task 3: Add forest context handling to `migrate`
+- File: `src/cli.ts`
+- In the `migrate` command handler, add an `if (context === "forest")` branch before the `if (context === "repo")` branch
+- Mirror what `init` does for the same case: print "already a forest" header and tree listing
+- Refactor the shared output into a small helper if duplication grows
+
+### Task 4: Tests
+- Add unit tests for `confirm()` covering empty/y/n/yes/no/typo with both defaults
+- Add an integration test for `migrate` from inside a forest (asserts no clone prompt, prints listing)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import readline from "readline/promises";
 import chalk from "chalk";
 import path from "path";
 import { statusTrees, formatTreeLine } from "./commands/status.js";
+import { parseConfirmAnswer } from "./prompt.js";
 
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json");
@@ -29,14 +30,38 @@ function printCdHint(dir: string): void {
   console.log(chalk.whiteBright(`cd ${dir}`));
 }
 
-async function confirm(question: string): Promise<boolean> {
+async function printForestSummary(headerPrefix: string): Promise<void> {
+  const { forestRoot, repoName, trees } = await statusTrees(process.cwd());
+  if (trees.length === 0) {
+    console.log(`${headerPrefix}, no trees found.`);
+    return;
+  }
+  const activeTree = trees.find((t) => t.active);
+  if (activeTree) {
+    console.log(`${headerPrefix}. on branch ${chalk.green(activeTree.branch)} in ${chalk.whiteBright(repoName)}`);
+  } else {
+    console.log(`${headerPrefix}. in ${chalk.whiteBright(repoName)}`);
+  }
+  console.log();
+  console.log("trees:");
+  for (const tree of trees) {
+    const prefix = tree.active ? "* " : tree.isDefault ? "  " : "+ ";
+    const branch = tree.active
+      ? chalk.green(tree.branch)
+      : tree.isDefault ? tree.branch : chalk.cyan(tree.branch);
+    const rel = chalk.whiteBright("./" + path.relative(forestRoot, tree.path));
+    console.log(`${prefix}${branch}  ${rel}`);
+  }
+}
+
+async function confirm(question: string, defaultYes: boolean): Promise<boolean> {
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
   });
   const answer = await rl.question(question);
   rl.close();
-  return answer.toLowerCase() !== "n";
+  return parseConfirmAnswer(answer, defaultYes);
 }
 
 const program = new Command();
@@ -95,6 +120,7 @@ program
       if (!opts.yes) {
         const ok = await confirm(
           `clone ${org}/${repoName} to ${targetPath}? (Y/n) `,
+          true,
         );
         if (!ok) {
           console.log("aborted.");
@@ -163,7 +189,9 @@ program
       const verbose = program.opts().verbose || config.verbose;
       const context = await detectContext(process.cwd());
 
-      if (context === "repo") {
+      if (context === "forest") {
+        await printForestSummary("already a forest");
+      } else if (context === "repo") {
         const { getLocalBranch, getRepoRoot, listLocalBranches } = await import("./git.js");
         const gitRoot = await getRepoRoot(process.cwd());
         const branch = await getLocalBranch(gitRoot);
@@ -177,7 +205,7 @@ program
         console.log();
 
         console.log("no files will be changed, folder rename only.");
-        const ok = await confirm("migrate to forest layout? (y/N) ");
+        const ok = await confirm("migrate to forest layout? (y/N) ", false);
         if (!ok) {
           console.log("aborted.");
           return;
@@ -221,29 +249,7 @@ program
       const context = await detectContext(process.cwd());
 
       if (context === "forest") {
-        const { forestRoot, repoName, trees } = await statusTrees(process.cwd());
-        if (trees.length === 0) {
-          console.log("forest detected, no trees found.");
-          return;
-        }
-        const activeTree = trees.find((t) => t.active);
-        if (activeTree) {
-          console.log(`already a forest. on branch ${chalk.green(activeTree.branch)} in ${chalk.whiteBright(repoName)}`);
-        } else {
-          console.log(`already a forest. in ${chalk.whiteBright(repoName)}`);
-        }
-        console.log();
-        console.log("trees:");
-        for (const tree of trees) {
-          const prefix = tree.active ? "* " : tree.isDefault ? "  " : "+ ";
-          const branch = tree.active
-            ? chalk.green(tree.branch)
-            : tree.isDefault ? tree.branch : chalk.cyan(tree.branch);
-          const rel = chalk.whiteBright(
-            "./" + path.relative(forestRoot, tree.path),
-          );
-          console.log(`${prefix}${branch}  ${rel}`);
-        }
+        await printForestSummary("already a forest");
       } else if (context === "repo") {
         const { getLocalBranch, getRepoRoot, listLocalBranches } = await import("./git.js");
         const gitRoot = await getRepoRoot(process.cwd());
@@ -259,7 +265,7 @@ program
         console.log();
 
         console.log("no files will be changed, folder rename only.");
-        const ok = await confirm("migrate to forest layout? (y/N) ");
+        const ok = await confirm("migrate to forest layout? (y/N) ", false);
         if (!ok) {
           console.log("aborted.");
           return;

--- a/src/prompt.test.ts
+++ b/src/prompt.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { parseConfirmAnswer } from "./prompt.js";
+
+describe("parseConfirmAnswer", () => {
+  it("returns defaultYes=true on empty input", () => {
+    expect(parseConfirmAnswer("", true)).toBe(true);
+  });
+
+  it("returns defaultYes=false on empty input", () => {
+    expect(parseConfirmAnswer("", false)).toBe(false);
+  });
+
+  it("returns defaultYes on whitespace-only input", () => {
+    expect(parseConfirmAnswer("   ", true)).toBe(true);
+    expect(parseConfirmAnswer("   ", false)).toBe(false);
+  });
+
+  it("returns true for y/yes regardless of default", () => {
+    expect(parseConfirmAnswer("y", false)).toBe(true);
+    expect(parseConfirmAnswer("Y", false)).toBe(true);
+    expect(parseConfirmAnswer("yes", false)).toBe(true);
+    expect(parseConfirmAnswer("YES", true)).toBe(true);
+  });
+
+  it("returns false for n/no regardless of default", () => {
+    expect(parseConfirmAnswer("n", true)).toBe(false);
+    expect(parseConfirmAnswer("N", true)).toBe(false);
+    expect(parseConfirmAnswer("no", true)).toBe(false);
+    expect(parseConfirmAnswer("NO", false)).toBe(false);
+  });
+
+  it("returns defaultYes for typos", () => {
+    expect(parseConfirmAnswer("yse", true)).toBe(true);
+    expect(parseConfirmAnswer("yse", false)).toBe(false);
+    expect(parseConfirmAnswer("maybe", true)).toBe(true);
+  });
+});

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -1,0 +1,7 @@
+export function parseConfirmAnswer(answer: string, defaultYes: boolean): boolean {
+  const a = answer.trim().toLowerCase();
+  if (a === "") return defaultYes;
+  if (a === "y" || a === "yes") return true;
+  if (a === "n" || a === "no") return false;
+  return defaultYes;
+}


### PR DESCRIPTION
## Summary
- `confirm()` now takes explicit `defaultYes` parameter — pressing enter at `(y/N)` correctly aborts (fixed accidental migration bug)
- `migrate` now detects forest context and prints "already a forest" with tree listing instead of incorrectly prompting to clone
- Extracted `parseConfirmAnswer` to `src/prompt.ts` with 6 unit tests
- Extracted `printForestSummary` helper shared by `init` and `migrate`

OpenSpec change: `openspec/changes/fix-confirm-default-and-migrate-forest-context/`