### PR TITLE
docs: add Claude Code session resume snippet for post-migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,18 @@ claude plugin add dwmkerr/git-workforest
 
 This adds a `workforest` skill that teaches the agent how to list trees, add branches, navigate between trees, and work with the forest directory structure.
 
+### Resuming a Claude Code session after `migrate`
+
+`migrate` moves your repo into a subdirectory, which changes Claude Code's project key (it's derived from `cwd`). To resume an existing session and keep your file-based memory, symlink the new project key to the old one:
+
+```bash
+d=$(pwd); while [ "$d" != "/" ]; do k=$(echo "$d" | tr '/_' '--'); [ -d "$HOME/.claude/projects/$k" ] && break; d=$(dirname "$d"); done
+ln -sfn "$HOME/.claude/projects/$k" "$HOME/.claude/projects/$(pwd | tr '/_' '--')"
+claude --resume
+```
+
+The walk-up loop handles nested branch names (e.g. `feat/foo/`).
+
 ## Developer guide
 
 Clone and install:


### PR DESCRIPTION
## Summary
- Adds a 3-line snippet to the Claude Code section of the README explaining how to resume a Claude session after `git forest migrate`.

## Why
`migrate` changes `cwd`, which changes Claude Code's project key (the key is the cwd path with `/` and `_` replaced by `-`). Existing sessions and file-based memory live under the old key, so `claude --resume` finds nothing in the new tree dir. Symlinking the new key to the old one preserves session list and memory.

The walk-up loop handles nested branch names (e.g. `feat/foo/` produces a tree at `<repo>/feat/foo/` two levels deep).