### PR TITLE
chore: pin openspec-flow to v0.1.6

### DIFF
--- a/.github/workflows/openspec-flow.yml
+++ b/.github/workflows/openspec-flow.yml
@@ -12,7 +12,7 @@ on:
     types: [created]
 jobs:
   flow:
-    uses: dwmkerr/openspec-flow/.github/workflows/openspec-flow.yml@main
+    uses: dwmkerr/openspec-flow/.github/workflows/openspec-flow.yml@v0.1.6
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       OPENSPEC_FLOW_APP_ID: ${{ secrets.OPENSPEC_FLOW_APP_ID || '' }}


### PR DESCRIPTION
## Summary

Pin the openspec-flow reusable workflow to the fixed `v0.1.6` release instead of tracking the moving `main` branch.

This release fixes the composite action manifest failure seen on issue #65.

## Validation

- confirmed the `v0.1.6` tag and GitHub Release are published
- confirmed the tagged composite manifest contains no unsupported `vars` references
- `actionlint .github/workflows/openspec-flow.yml`