### PR TITLE
chore: pin openspec-flow to v0.1.7

### DIFF
--- a/.github/workflows/openspec-flow.yml
+++ b/.github/workflows/openspec-flow.yml
@@ -12,7 +12,7 @@ on:
     types: [created]
 jobs:
   flow:
-    uses: dwmkerr/openspec-flow/.github/workflows/openspec-flow.yml@v0.1.6
+    uses: dwmkerr/openspec-flow/.github/workflows/openspec-flow.yml@v0.1.7
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       OPENSPEC_FLOW_APP_ID: ${{ secrets.OPENSPEC_FLOW_APP_ID || '' }}


### PR DESCRIPTION
## Summary

Pin openspec-flow to `v0.1.7`.

The prior `v0.1.6` pin proved the composite manifest now loads, but live run 29999169211 exposed an invalid setup-node cache path. v0.1.7 removes that cache configuration and adds regression coverage.

## Validation

- v0.1.7 GitHub Release published
- openspec-flow CI passes on Node 22 and 24
- `actionlint .github/workflows/openspec-flow.yml`