### PR TITLE
chore: use OAuth with openspec-flow v0.1.8

### DIFF
--- a/.github/workflows/openspec-flow.yml
+++ b/.github/workflows/openspec-flow.yml
@@ -12,8 +12,8 @@ on:
     types: [created]
 jobs:
   flow:
-    uses: dwmkerr/openspec-flow/.github/workflows/openspec-flow.yml@v0.1.7
+    uses: dwmkerr/openspec-flow/.github/workflows/openspec-flow.yml@v0.1.8
     secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       OPENSPEC_FLOW_APP_ID: ${{ secrets.OPENSPEC_FLOW_APP_ID || '' }}
       OPENSPEC_FLOW_PRIVATE_KEY: ${{ secrets.OPENSPEC_FLOW_PRIVATE_KEY || '' }}


### PR DESCRIPTION
## Summary

- upgrade the reusable OpenSpec Flow workflow to v0.1.8
- authenticate Claude with the shared `CLAUDE_CODE_OAUTH_TOKEN` secret
- retain the existing GitHub App credential mappings

## Validation

- `actionlint .github/workflows/openspec-flow.yml`