### PR TITLE
feat: add packaged man pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ git forest remove fix-typo
 
 Commands mirror `git worktree` semantics — `list`, `add`, `remove` — but workforest handles paths automatically. You can also use the aliases `git-workforest` or `workforest`.
 
+The global install also includes offline reference documentation:
+
+```bash
+man workforest
+git help forest
+```
+
 ## Worktree folder structure
 
 Each branch gets its own folder inside the forest:

--- a/man/git-forest.1
+++ b/man/git-forest.1
@@ -1,0 +1,1 @@
+.so man1/workforest.1

--- a/man/git-workforest.1
+++ b/man/git-workforest.1
@@ -1,0 +1,1 @@
+.so man1/workforest.1

--- a/man/workforest.1
+++ b/man/workforest.1
@@ -1,0 +1,77 @@
+.TH WORKFOREST 1 "" "workforest" "User Commands"
+.SH NAME
+workforest, git\-forest, git\-workforest \- Manage git worktrees with a simple, predictable folder structure.
+.SH SYNOPSIS
+.B "workforest [options] [command]"
+.br
+.B "git forest [options] [command]"
+.br
+.B "git workforest [options] [command]"
+.SH DESCRIPTION
+Manage git worktrees with a simple, predictable folder structure.
+.PP
+Workforest manages one clone as a structured forest of Git worktrees, with each branch in its own folder.
+.SH OPTIONS
+.TP
+.B "\-V, \-\-version"
+output the version number
+.TP
+.B "\-v, \-\-verbose"
+show git command output
+.TP
+.B "\-h, \-\-help"
+display help for command
+.SH COMMANDS
+.TP
+.B "clone [options] <repo>"
+Clone a GitHub repo into the structured forest path
+.RS
+.TP
+.B "\-y, \-\-yes"
+Skip confirmation prompt
+.RE
+.TP
+.B "add|checkout <branch> [gitArgs...]"
+add a tree for a branch (like git worktree add)
+.TP
+.B "migrate"
+Migrate an existing repo to forest layout, or clone a new one
+.TP
+.B "init"
+Detect context and set up a forest (migrate, clone, or show status)
+.TP
+.B "list|status|ls"
+list all trees in the forest (like git worktree list)
+.TP
+.B "remove|delete [options] <branch> [gitArgs...]"
+remove a tree from the forest (like git worktree remove)
+.RS
+.TP
+.B "\-f, \-\-force"
+force removal even if tree has uncommitted changes
+.RE
+.TP
+.B "help [command]"
+display help for command
+.SH EXAMPLES
+.nf
+  # set up a forest (detects context automatically)
+  git forest init
+
+  # clone a repo into a structured forest
+  git forest clone dwmkerr/effective\-shell
+
+  # list all trees in the forest
+  git forest list
+
+  # add a new tree for a branch
+  git forest add fix/typo
+
+  # remove a tree
+  git forest remove fix/typo
+.fi
+.SH REPORTING BUGS
+Report issues at https://github.com/dwmkerr/git\-workforest/issues.
+.SH SEE ALSO
+.BR git (1),
+.BR git\-worktree (1)

--- a/openspec/changes/archive/2026-07-29-add-man-pages/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-29-add-man-pages/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/archive/2026-07-29-add-man-pages/design.md
+++ b/openspec/changes/archive/2026-07-29-add-man-pages/design.md
@@ -1,0 +1,57 @@
+## Context
+
+The package exposes three executable names backed by one Commander program. npm supports installing sectioned manual files from the `man` package field, and the active npm prefix is already part of the normal Unix manual search path. See `proposal.md` and `specs/man-pages/spec.md` for motivation and required behavior.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep CLI help and manual-page command reference derived from one command model.
+- Make local development and npm packing reproducible without operating-system-specific generation tools.
+- Support both direct executable names and Git's `git help forest` convention.
+
+**Non-Goals:**
+
+- Install manual pages for ephemeral `npx` executions.
+- Add Windows manual-page behavior.
+- Replace Commander's existing terminal help or maintain independent prose for every command.
+- Introduce a general-purpose roff generation dependency.
+
+## Decisions
+
+### Render section 1 roff directly from the Commander model
+
+Add a small TypeScript renderer that accepts the exported Commander program and emits the conventional NAME, SYNOPSIS, DESCRIPTION, OPTIONS, COMMANDS, EXAMPLES, and SEE ALSO sections. The generator imports the compiled CLI with parsing disabled and writes deterministic output.
+
+This avoids duplicating command metadata and avoids external tools such as `help2man`, `ronn`, or `marked-man`. Those alternatives either add a platform dependency, introduce a development dependency for a limited format, or require a separate Markdown command reference that can drift.
+
+### Ship one canonical page and two roff aliases
+
+`man/workforest.1` contains the generated reference. `man/git-forest.1` and `man/git-workforest.1` use the standard roff `.so man1/workforest.1` redirect. All three filenames are declared in the npm `man` array so npm links them into the section 1 manual directory.
+
+Duplicating the full page three times was rejected because it increases package size and creates multiple generated artifacts that could diverge.
+
+### Check generated files into source control and verify exact equality
+
+Generated pages remain reviewable in pull requests. A Vitest test renders from the in-memory Commander program and compares exact bytes with the checked-in files. This makes command metadata drift fail the existing CI test suite without coupling generated files to Release Please version bumps.
+
+Keeping pages only as build artifacts was rejected because release contents would be harder to review and local source installs could depend on lifecycle behavior.
+
+### Regenerate during npm prepack
+
+An npm script builds the TypeScript sources and runs the generator. The `prepack` lifecycle invokes that script, ensuring `npm pack` and `npm publish` select fresh manual pages even if a developer did not run the generator manually.
+
+## Risks / Trade-offs
+
+- **The small roff renderer supports only Workforest's current Commander metadata** → Keep it intentionally scoped and cover all emitted sections with snapshot-like equality tests.
+- **Alias pages depend on standard `.so` resolution** → Validate each installed alias with the host `man` implementation during packaging verification.
+- **npm only installs manual pages for global Unix-style installations** → Document this platform boundary; command help remains available everywhere with `--help`.
+- **Prepack builds twice in the current release workflow** → Accept the small redundant build to keep standalone `npm pack` safe and self-contained.
+
+## Migration Plan
+
+1. Publish the package through the existing Release Please workflow.
+2. Verify the release tarball contains all three section 1 pages.
+3. Globally install the release and smoke-test `man workforest`, both aliases, and `git help forest`.
+
+Rollback requires publishing a follow-up version that removes the npm `man` metadata; no user configuration or data migration is involved.

--- a/openspec/changes/archive/2026-07-29-add-man-pages/proposal.md
+++ b/openspec/changes/archive/2026-07-29-add-man-pages/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Workforest is installed as a Unix command-line tool, but its npm package does not install manual pages. Users cannot open offline reference documentation with `man workforest` or use Git's familiar `git help forest` flow.
+
+## What Changes
+
+- Generate a section 1 manual page from Workforest's Commander command model.
+- Package manual pages for the `workforest`, `git-forest`, and `git-workforest` executable names.
+- Keep the checked-in manual pages synchronized with the CLI through automated tests and npm's packaging lifecycle.
+- Verify the packed npm artifact installs and renders each manual-page alias.
+
+## Capabilities
+
+### New Capabilities
+
+- `man-pages`: Install and maintain Unix manual pages for every shipped Workforest executable name.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Adds a man-page renderer and generator script.
+- Adds generated files under `man/` and tests that detect drift from the CLI model.
+- Updates `package.json` package contents, lifecycle scripts, and `man` metadata.
+- Does not change runtime command behavior or add runtime dependencies.

--- a/openspec/changes/archive/2026-07-29-add-man-pages/specs/man-pages/spec.md
+++ b/openspec/changes/archive/2026-07-29-add-man-pages/specs/man-pages/spec.md
@@ -1,0 +1,39 @@
+## Purpose
+
+Provide locally installed reference documentation for every Workforest executable name and Git's external-command help convention.
+
+## ADDED Requirements
+
+### Requirement: Package installs manual pages for all executable names
+The npm package SHALL install section 1 manual pages named `workforest`, `git-forest`, and `git-workforest` on platforms that support npm manual-page installation.
+
+#### Scenario: Open the primary manual page
+- **WHEN** a user globally installs the package and runs `man workforest`
+- **THEN** the system SHALL display the Workforest manual page
+
+#### Scenario: Open a Git command alias manual page
+- **WHEN** a user globally installs the package and runs `man git-forest` or `man git-workforest`
+- **THEN** the system SHALL display the same Workforest manual content
+
+#### Scenario: Open help through Git
+- **WHEN** a user globally installs the package and runs `git help forest`
+- **THEN** Git SHALL be able to locate the `git-forest` manual page
+
+### Requirement: Manual page documents the shipped command interface
+The Workforest manual page SHALL document the executable forms, global options, commands, command aliases, command options, examples, and related Git commands represented by the shipped CLI.
+
+#### Scenario: Read command reference
+- **WHEN** a user opens any Workforest manual-page name
+- **THEN** the page SHALL contain synopsis, description, options, commands, examples, and see-also sections
+- **AND** the commands and aliases SHALL match the shipped CLI command model
+
+### Requirement: Package generation detects stale manual content
+The project SHALL generate manual content deterministically from the shipped CLI command model and SHALL fail automated validation when checked-in manual content is stale.
+
+#### Scenario: CLI command model changes without regenerating manuals
+- **WHEN** commands, aliases, options, descriptions, or examples change without corresponding manual regeneration
+- **THEN** the automated test suite SHALL fail
+
+#### Scenario: npm artifact is packed
+- **WHEN** the project creates an npm package artifact
+- **THEN** the package lifecycle SHALL regenerate the manual pages before selecting package contents

--- a/openspec/changes/archive/2026-07-29-add-man-pages/tasks.md
+++ b/openspec/changes/archive/2026-07-29-add-man-pages/tasks.md
@@ -1,0 +1,15 @@
+## 1. Man Page Generation
+
+- [x] 1.1 Add a deterministic roff renderer for the exported Commander program
+- [x] 1.2 Add a generator script and create canonical and alias section 1 pages
+
+## 2. Package Integration
+
+- [x] 2.1 Declare the manual files and generator in npm package contents
+- [x] 2.2 Regenerate manual pages during the npm prepack lifecycle
+
+## 3. Verification
+
+- [x] 3.1 Add tests that compare checked-in pages with the current CLI model and package metadata
+- [x] 3.2 Run lint, tests, build, and strict OpenSpec validation
+- [x] 3.3 Pack and install into a temporary npm prefix, then render every manual alias and `git help forest`

--- a/openspec/specs/man-pages/spec.md
+++ b/openspec/specs/man-pages/spec.md
@@ -1,0 +1,38 @@
+# man-pages Specification
+
+## Purpose
+Provide locally installed reference documentation for every Workforest executable name and Git's external-command help convention.
+## Requirements
+### Requirement: Package installs manual pages for all executable names
+The npm package SHALL install section 1 manual pages named `workforest`, `git-forest`, and `git-workforest` on platforms that support npm manual-page installation.
+
+#### Scenario: Open the primary manual page
+- **WHEN** a user globally installs the package and runs `man workforest`
+- **THEN** the system SHALL display the Workforest manual page
+
+#### Scenario: Open a Git command alias manual page
+- **WHEN** a user globally installs the package and runs `man git-forest` or `man git-workforest`
+- **THEN** the system SHALL display the same Workforest manual content
+
+#### Scenario: Open help through Git
+- **WHEN** a user globally installs the package and runs `git help forest`
+- **THEN** Git SHALL be able to locate the `git-forest` manual page
+
+### Requirement: Manual page documents the shipped command interface
+The Workforest manual page SHALL document the executable forms, global options, commands, command aliases, command options, examples, and related Git commands represented by the shipped CLI.
+
+#### Scenario: Read command reference
+- **WHEN** a user opens any Workforest manual-page name
+- **THEN** the page SHALL contain synopsis, description, options, commands, examples, and see-also sections
+- **AND** the commands and aliases SHALL match the shipped CLI command model
+
+### Requirement: Package generation detects stale manual content
+The project SHALL generate manual content deterministically from the shipped CLI command model and SHALL fail automated validation when checked-in manual content is stale.
+
+#### Scenario: CLI command model changes without regenerating manuals
+- **WHEN** commands, aliases, options, descriptions, or examples change without corresponding manual regeneration
+- **THEN** the automated test suite SHALL fail
+
+#### Scenario: npm artifact is packed
+- **WHEN** the project creates an npm package artifact
+- **THEN** the package lifecycle SHALL regenerate the manual pages before selecting package contents

--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
     "git-workforest": "./bin/git-workforest.js",
     "git-forest": "./bin/git-workforest.js"
   },
+  "man": [
+    "./man/workforest.1",
+    "./man/git-forest.1",
+    "./man/git-workforest.1"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -17,6 +22,8 @@
   "files": [
     "dist",
     "bin",
+    "man",
+    "scripts/generate-manpages.mjs",
     "!dist/**/*.test.js",
     "!dist/**/*.map"
   ],
@@ -30,7 +37,10 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "man": "npm run build --silent && node scripts/generate-manpages.mjs",
+    "man:check": "npm run build --silent && node scripts/generate-manpages.mjs --check",
+    "prepack": "npm run man"
   },
   "dependencies": {
     "chalk": "^5.5.0",

--- a/scripts/generate-manpages.mjs
+++ b/scripts/generate-manpages.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+process.env.VITEST = process.env.VITEST ?? "manpage-generator";
+
+const [{ helpExamples, program }, { manPageFiles, renderManPages }] =
+  await Promise.all([
+    import("../dist/cli.js"),
+    import("../dist/manpage.js"),
+  ]);
+
+const check = process.argv.includes("--check");
+const manDir = resolve("man");
+const pages = renderManPages(program, helpExamples);
+let stale = false;
+
+if (!check) {
+  await mkdir(manDir, { recursive: true });
+}
+
+for (const filename of manPageFiles) {
+  const path = resolve(manDir, filename);
+  const expected = pages[filename];
+
+  if (check) {
+    let actual;
+    try {
+      actual = await readFile(path, "utf8");
+    } catch {
+      actual = undefined;
+    }
+
+    if (actual !== expected) {
+      console.error(`stale man page: ${filename}`);
+      stale = true;
+    }
+  } else {
+    await writeFile(path, expected, "utf8");
+    console.log(`generated man/${filename}`);
+  }
+}
+
+if (stale) {
+  console.error("run npm run man to regenerate manual pages");
+  process.exitCode = 1;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,18 +66,7 @@ async function confirm(question: string, defaultYes: boolean): Promise<boolean> 
 
 export const program = new Command();
 
-program
-  .name("git-workforest")
-  .description(
-    "Manage git worktrees with a simple, predictable folder structure.",
-  )
-  .version(version)
-  .option("-v, --verbose", "show git command output")
-  .addHelpText(
-    "after",
-    `
-examples:
-
+export const helpExamples = `
   # set up a forest (detects context automatically)
   git forest init
 
@@ -91,7 +80,18 @@ examples:
   git forest add fix/typo
 
   # remove a tree
-  git forest remove fix/typo`,
+  git forest remove fix/typo`;
+
+program
+  .name("git-workforest")
+  .description(
+    "Manage git worktrees with a simple, predictable folder structure.",
+  )
+  .version(version)
+  .option("-v, --verbose", "show git command output")
+  .addHelpText(
+    "after",
+    `\nexamples:\n${helpExamples}`,
   );
 
 // Show all aliases (not just the first) in the subcommand summary of `--help`,

--- a/src/manpage.test.ts
+++ b/src/manpage.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { createRequire } from "module";
+import { helpExamples, program } from "./cli.js";
+import {
+  manPageFiles,
+  renderAliasManPage,
+  renderManPages,
+  renderPrimaryManPage,
+} from "./manpage.js";
+
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json");
+
+describe("man pages", () => {
+  it("renders the shipped CLI commands, aliases, options, and examples", () => {
+    const manPage = renderPrimaryManPage(program, helpExamples);
+
+    expect(manPage).toContain("workforest, git\\-forest, git\\-workforest");
+    expect(manPage).toContain("clone [options] <repo>");
+    expect(manPage).toContain("add|checkout <branch> [gitArgs...]");
+    expect(manPage).toContain("list|status|ls");
+    expect(manPage).toContain("remove|delete [options] <branch> [gitArgs...]");
+    expect(manPage).toContain("\\-f, \\-\\-force");
+    expect(manPage).toContain("git forest init");
+  });
+
+  it("uses the canonical page for executable aliases", () => {
+    expect(renderAliasManPage()).toBe(".so man1/workforest.1\n");
+  });
+
+  it("keeps checked-in pages synchronized with the CLI model", () => {
+    const rendered = renderManPages(program, helpExamples);
+
+    for (const filename of manPageFiles) {
+      const checkedIn = readFileSync(resolve("man", filename), "utf8");
+      expect(checkedIn, filename).toBe(rendered[filename]);
+    }
+  });
+
+  it("declares every manual page in the npm package", () => {
+    expect(packageJson.man).toEqual(
+      manPageFiles.map((filename) => `./man/${filename}`),
+    );
+    expect(packageJson.files).toContain("man");
+    expect(packageJson.files).toContain("scripts/generate-manpages.mjs");
+  });
+});

--- a/src/manpage.ts
+++ b/src/manpage.ts
@@ -1,0 +1,129 @@
+import type { Command, Option } from "commander";
+
+export const manPageFiles = [
+  "workforest.1",
+  "git-forest.1",
+  "git-workforest.1",
+] as const;
+
+function escapeRoff(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/-/g, "\\-")
+    .replace(/^([.'])/gm, "\\&$1");
+}
+
+function quoted(value: string): string {
+  return `"${escapeRoff(value).replace(/"/g, "\\(dq")}"`;
+}
+
+function renderOption(option: Option): string[] {
+  return [
+    ".TP",
+    `.B ${quoted(option.flags)}`,
+    escapeRoff(option.description),
+  ];
+}
+
+function commandTerm(command: Command): string {
+  const aliases = command.aliases();
+  const names = [command.name(), ...aliases].join("|");
+  const options = command.options.length > 0 ? " [options]" : "";
+  const args = command.registeredArguments
+    .map((argument) => {
+      const name = `${argument.name()}${argument.variadic ? "..." : ""}`;
+      return argument.required ? `<${name}>` : `[${name}]`;
+    })
+    .join(" ");
+
+  return `${names}${options}${args ? ` ${args}` : ""}`;
+}
+
+function renderCommand(command: Command): string[] {
+  const lines = [
+    ".TP",
+    `.B ${quoted(commandTerm(command))}`,
+    escapeRoff(command.description()),
+  ];
+
+  if (command.options.length > 0) {
+    lines.push(".RS");
+    for (const option of command.options) {
+      lines.push(...renderOption(option));
+    }
+    lines.push(".RE");
+  }
+
+  return lines;
+}
+
+export function renderPrimaryManPage(
+  program: Command,
+  examples: string,
+): string {
+  const description = program.description();
+  const lines = [
+    `.TH WORKFOREST 1 "" "workforest" "User Commands"`,
+    ".SH NAME",
+    `${escapeRoff("workforest, git-forest, git-workforest")} \\- ${escapeRoff(description)}`,
+    ".SH SYNOPSIS",
+    `.B ${quoted("workforest [options] [command]")}`,
+    ".br",
+    `.B ${quoted("git forest [options] [command]")}`,
+    ".br",
+    `.B ${quoted("git workforest [options] [command]")}`,
+    ".SH DESCRIPTION",
+    escapeRoff(description),
+    ".PP",
+    "Workforest manages one clone as a structured forest of Git worktrees, with each branch in its own folder.",
+    ".SH OPTIONS",
+  ];
+
+  for (const option of program.options) {
+    lines.push(...renderOption(option));
+  }
+  lines.push(
+    ".TP",
+    `.B ${quoted("-h, --help")}`,
+    "display help for command",
+    ".SH COMMANDS",
+  );
+
+  for (const command of program.commands) {
+    lines.push(...renderCommand(command));
+  }
+  lines.push(
+    ".TP",
+    `.B ${quoted("help [command]")}`,
+    "display help for command",
+    ".SH EXAMPLES",
+    ".nf",
+    escapeRoff(examples.replace(/^\n/, "").trimEnd()),
+    ".fi",
+    ".SH REPORTING BUGS",
+    escapeRoff("Report issues at https://github.com/dwmkerr/git-workforest/issues."),
+    ".SH SEE ALSO",
+    ".BR git (1),",
+    ".BR git\\-worktree (1)",
+  );
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function renderAliasManPage(): string {
+  return ".so man1/workforest.1\n";
+}
+
+export function renderManPages(
+  program: Command,
+  examples: string,
+): Record<(typeof manPageFiles)[number], string> {
+  const primary = renderPrimaryManPage(program, examples);
+  const alias = renderAliasManPage();
+
+  return {
+    "workforest.1": primary,
+    "git-forest.1": alias,
+    "git-workforest.1": alias,
+  };
+}


### PR DESCRIPTION
## Summary

- generate a section 1 manual from the Commander command model
- package `workforest`, `git-forest`, and `git-workforest` manual names
- support `man workforest` and `git help forest` after global npm install
- regenerate at prepack time and test checked-in pages for CLI drift
- add and archive the validated OpenSpec `man-pages` capability

## Validation

- `npm run lint`
- `npm run test:coverage` (73 tests)
- `npm run man:check`
- strict validation passes for the new `man-pages` OpenSpec
- `npm pack` plus install into a temporary global prefix
- rendered `man workforest`, `man git-forest`, `man git-workforest`, and `git help forest`

## Release

After this PR is merged, Release Please will create or update the release PR. Merging that release PR publishes the npm package.