### PR TITLE
fix: keep releases on 0.1.x line

### DIFF
--- a/openspec/changes/archive/2026-07-29-keep-0-1-release-line/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-29-keep-0-1-release-line/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/archive/2026-07-29-keep-0-1-release-line/design.md
+++ b/openspec/changes/archive/2026-07-29-keep-0-1-release-line/design.md
@@ -1,0 +1,39 @@
+## Context
+
+The manifest and package are at `0.1.0`, while the unreleased commit range contains a breaking-change footer. The current combination of `bump-minor-pre-major` and `bump-patch-for-minor-pre-major` makes ordinary features patch releases but still makes pre-1.0 breaking changes minor releases.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep all automated releases on `0.1.x` until the policy is deliberately changed.
+- Express that policy with a single unambiguous Release Please setting.
+
+**Non-Goals:**
+
+- Remove breaking-change entries from the changelog.
+- Rewrite historical commits or tags.
+- Define the eventual criteria for moving to `0.2.0` or `1.0.0`.
+
+## Decisions
+
+### Use the `always-bump-patch` versioning strategy
+
+Set the package's `versioning` option to `always-bump-patch`. This official Release Please strategy returns a patch update for every releasable commit set, including breaking changes.
+
+Remove both pre-major flags. `bump-patch-for-minor-pre-major` affects feature commits but does not override breaking changes, while `bump-minor-pre-major` explicitly maps breaking changes to a minor bump. Keeping them alongside the explicit strategy would make the intended policy less clear.
+
+**Alternative considered:** Add a one-time `Release-As: 0.1.1` footer. This can repair the current PR but does not prevent the same issue on later releases.
+
+## Risks / Trade-offs
+
+- **Breaking changes no longer communicate severity through the version number** → Preserve the breaking-change section in the generated changelog and change the strategy deliberately when the project is ready to advance the minor line.
+- **The open release PR may retain stale state briefly after merge** → Wait for the next Release Please workflow run to force-update it before merging the release PR.
+
+## Migration Plan
+
+1. Merge the configuration change to `main`.
+2. Confirm Release Please rewrites PR #52 from `0.2.0` to `0.1.1`.
+3. Merge the updated release PR to publish the patch release.
+
+Rollback by restoring the default versioning strategy if minor or major semantic bumps become desired.

--- a/openspec/changes/archive/2026-07-29-keep-0-1-release-line/proposal.md
+++ b/openspec/changes/archive/2026-07-29-keep-0-1-release-line/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Workforest is intentionally staying on the `0.1.x` release line, but the current pre-major flags still allow a historical `BREAKING CHANGE` commit to advance the release to `0.2.0`. The open Release Please PR is therefore proposing the wrong version despite normal feature commits being configured as patch bumps.
+
+## What Changes
+
+- Use Release Please's explicit `always-bump-patch` versioning strategy.
+- Remove the overlapping pre-major bump flags that still permit minor releases.
+- Require every automated release from `0.1.0` to remain on the `0.1.x` line until the versioning policy is deliberately changed.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `release-automation`: Automated releases must use patch-only version increments while Workforest remains on the `0.1.x` line.
+
+## Impact
+
+- Updates `release-please-config.json` and normalizes the legacy `release-automation` spec structure for current OpenSpec tooling.
+- Causes Release Please to recalculate the open release PR from `0.2.0` to `0.1.1` after this change reaches `main`.
+- Breaking-change annotations remain visible in the changelog but do not advance the minor version.

--- a/openspec/changes/archive/2026-07-29-keep-0-1-release-line/specs/release-automation/spec.md
+++ b/openspec/changes/archive/2026-07-29-keep-0-1-release-line/specs/release-automation/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Pre-1.0 releases remain on the 0.1.x line
+The system SHALL increment only the patch component for automated releases while Workforest is configured to remain on the `0.1.x` line, regardless of whether accumulated commits contain features or breaking-change annotations.
+
+#### Scenario: Feature commit is released
+- **WHEN** the current version is `0.1.0` and unreleased commits include a `feat:` commit
+- **THEN** Release Please SHALL propose version `0.1.1`
+
+#### Scenario: Breaking commit is released
+- **WHEN** the current version is `0.1.0` and unreleased commits include a breaking-change annotation
+- **THEN** Release Please SHALL propose version `0.1.1`
+- **AND** SHALL NOT propose version `0.2.0` or `1.0.0`
+
+#### Scenario: Subsequent patch release
+- **WHEN** the current version is `0.1.1` and another releasable commit is accumulated
+- **THEN** Release Please SHALL propose version `0.1.2`

--- a/openspec/changes/archive/2026-07-29-keep-0-1-release-line/tasks.md
+++ b/openspec/changes/archive/2026-07-29-keep-0-1-release-line/tasks.md
@@ -1,0 +1,9 @@
+## 1. Release Please Configuration
+
+- [x] 1.1 Replace the pre-major bump flags with `versioning: always-bump-patch`
+- [x] 1.2 Validate the configuration against the Release Please schema
+
+## 2. Verification
+
+- [x] 2.1 Run strict OpenSpec validation and repository checks
+- [x] 2.2 Verify the official strategy returns a patch update even for breaking commits

--- a/openspec/specs/release-automation/spec.md
+++ b/openspec/specs/release-automation/spec.md
@@ -1,3 +1,11 @@
+# release-automation Specification
+
+## Purpose
+
+Automate Workforest version calculation, changelog updates, GitHub releases, and authenticated npm publication from changes merged to the main branch.
+
+## Requirements
+
 ### Requirement: Release Please creates release PRs
 The system SHALL use Release Please to automatically create and maintain a release PR when conventional commits are pushed to `main`.
 
@@ -44,3 +52,19 @@ The release workflow SHALL use an `NPM_TOKEN` repository secret for npm authenti
 #### Scenario: NPM_TOKEN not configured
 - **WHEN** the release workflow runs the publish step and `NPM_TOKEN` is not set
 - **THEN** the publish step SHALL fail
+
+### Requirement: Pre-1.0 releases remain on the 0.1.x line
+The system SHALL increment only the patch component for automated releases while Workforest is configured to remain on the `0.1.x` line, regardless of whether accumulated commits contain features or breaking-change annotations.
+
+#### Scenario: Feature commit is released
+- **WHEN** the current version is `0.1.0` and unreleased commits include a `feat:` commit
+- **THEN** Release Please SHALL propose version `0.1.1`
+
+#### Scenario: Breaking commit is released
+- **WHEN** the current version is `0.1.0` and unreleased commits include a breaking-change annotation
+- **THEN** Release Please SHALL propose version `0.1.1`
+- **AND** SHALL NOT propose version `0.2.0` or `1.0.0`
+
+#### Scenario: Subsequent patch release
+- **WHEN** the current version is `0.1.1` and another releasable commit is accumulated
+- **THEN** Release Please SHALL propose version `0.1.2`

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,8 +4,7 @@
   "packages": {
     ".": {
       "release-type": "node",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "versioning": "always-bump-patch"
     }
   }
 }


### PR DESCRIPTION
## Summary

- replace overlapping pre-major flags with Release Please's explicit `always-bump-patch` strategy
- keep feature and breaking-change releases on the `0.1.x` line
- add and archive the corresponding `release-automation` OpenSpec requirement
- normalize the legacy release spec for current OpenSpec validation

## Why

PR #52 currently proposes `0.2.0` because the unreleased range includes a `BREAKING CHANGE`. The old flags make features patch releases but deliberately make pre-1.0 breaking changes minor releases. `always-bump-patch` forces the next release to `0.1.1`.

## Validation

- Release Please JSON schema validation
- strict `release-automation` OpenSpec validation
- `npm run lint`
- `npm test` (73 tests)

## After merge

Wait for Release Please to force-update PR #52 from `0.2.0` to `0.1.1` before merging the release PR.